### PR TITLE
Add configurable TUI columns and dashboard

### DIFF
--- a/crates/ticgit/src/cli.rs
+++ b/crates/ticgit/src/cli.rs
@@ -122,8 +122,8 @@ pub enum Command {
     /// Browse open tickets in an interactive terminal UI.
     Tui(commands::tui::Args),
 
-    /// Print a Markdown guide for AI agents.
-    Agent,
+    /// Print or install AI agent integration guidance.
+    Agent(commands::agent::Args),
 
     // -- Work on tickets --------------------------------------------------
     /// Select a ticket as "current" for subsequent commands.
@@ -253,10 +253,7 @@ pub fn run(cli: Cli) -> anyhow::Result<()> {
         }
         Some(Command::History(args)) => commands::history::run(args),
         Some(Command::Tui(args)) => commands::tui::run(args),
-        Some(Command::Agent) => {
-            crate::agent_help::print();
-            Ok(())
-        }
+        Some(Command::Agent(args)) => commands::agent::run(args),
         Some(Command::Tag(args)) => commands::tag::run(args),
         Some(Command::State(args)) => commands::state::run(args),
         Some(Command::Status(args)) => commands::state::run(args),

--- a/crates/ticgit/src/commands/agent.rs
+++ b/crates/ticgit/src/commands/agent.rs
@@ -1,0 +1,319 @@
+use std::fmt;
+use std::io::IsTerminal;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand, ValueEnum};
+use dialoguer::Select;
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Install TicGit instructions for an AI agent.
+    Skill(SkillArgs),
+}
+
+#[derive(Debug, Parser)]
+pub struct SkillArgs {
+    /// Installation target. If omitted in a terminal, prompts interactively.
+    #[arg(long = "target", value_enum)]
+    pub target: Option<SkillTarget>,
+
+    /// Check whether the selected target is already installed and current.
+    #[arg(long = "check")]
+    pub check: bool,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum SkillTarget {
+    AgentsMd,
+    AgentsLocal,
+    AgentsGlobal,
+    ClaudeLocal,
+    ClaudeGlobal,
+    OpenCodeLocal,
+    OpenCodeGlobal,
+    CodexLocal,
+    CodexGlobal,
+    CopilotLocal,
+    CopilotGlobal,
+    CursorLocal,
+    CursorGlobal,
+    WindsurfLocal,
+    WindsurfGlobal,
+}
+
+pub fn run(args: Args) -> Result<()> {
+    match args.command {
+        None => {
+            crate::agent_help::print();
+            Ok(())
+        }
+        Some(Command::Skill(args)) => install_skill(args),
+    }
+}
+
+fn install_skill(args: SkillArgs) -> Result<()> {
+    let target = match args.target {
+        Some(target) => target,
+        None if std::io::stdin().is_terminal() => prompt_target()?,
+        None => anyhow::bail!("--target is required when stdin is not interactive"),
+    };
+    let destination = target.destination()?;
+
+    if args.check {
+        if destination.is_current()? {
+            println!("{} is installed and current.", destination.path.display());
+            return Ok(());
+        }
+        anyhow::bail!(
+            "{} is not installed or is out of date",
+            destination.path.display()
+        );
+    }
+
+    destination.install()?;
+    println!(
+        "Installed TicGit agent instructions to {}.",
+        destination.path.display()
+    );
+    Ok(())
+}
+
+fn prompt_target() -> Result<SkillTarget> {
+    let targets = [
+        SkillTarget::AgentsMd,
+        SkillTarget::AgentsLocal,
+        SkillTarget::AgentsGlobal,
+        SkillTarget::ClaudeLocal,
+        SkillTarget::ClaudeGlobal,
+        SkillTarget::OpenCodeLocal,
+        SkillTarget::OpenCodeGlobal,
+        SkillTarget::CodexLocal,
+        SkillTarget::CodexGlobal,
+        SkillTarget::CopilotLocal,
+        SkillTarget::CopilotGlobal,
+        SkillTarget::CursorLocal,
+        SkillTarget::CursorGlobal,
+        SkillTarget::WindsurfLocal,
+        SkillTarget::WindsurfGlobal,
+    ];
+    let labels = targets
+        .iter()
+        .map(|target| target.prompt_label())
+        .collect::<Vec<_>>();
+    let selected = Select::new()
+        .with_prompt("Install TicGit agent instructions")
+        .items(&labels)
+        .default(0)
+        .interact()?;
+    Ok(targets[selected])
+}
+
+struct Destination {
+    path: PathBuf,
+    kind: DestinationKind,
+}
+
+enum DestinationKind {
+    AgentsMd,
+    Skill,
+}
+
+impl Destination {
+    fn install(&self) -> Result<()> {
+        match self.kind {
+            DestinationKind::AgentsMd => self.install_agents_md(),
+            DestinationKind::Skill => self.install_skill_file(),
+        }
+    }
+
+    fn is_current(&self) -> Result<bool> {
+        match self.kind {
+            DestinationKind::AgentsMd => Ok(std::fs::read_to_string(&self.path)
+                .map(|contents| contents.contains(agents_md_block().trim()))
+                .unwrap_or(false)),
+            DestinationKind::Skill => Ok(std::fs::read_to_string(&self.path)
+                .map(|contents| contents == skill_markdown())
+                .unwrap_or(false)),
+        }
+    }
+
+    fn install_agents_md(&self) -> Result<()> {
+        let existing = std::fs::read_to_string(&self.path).unwrap_or_default();
+        let next = if existing.contains(AGENTS_START) && existing.contains(AGENTS_END) {
+            replace_block(&existing, agents_md_block())
+        } else if existing.trim().is_empty() {
+            format!("{}\n", agents_md_block())
+        } else {
+            format!("{}\n\n{}\n", existing.trim_end(), agents_md_block())
+        };
+        std::fs::write(&self.path, next).with_context(|| format!("writing {}", self.path.display()))
+    }
+
+    fn install_skill_file(&self) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        std::fs::write(&self.path, skill_markdown())
+            .with_context(|| format!("writing {}", self.path.display()))
+    }
+}
+
+impl SkillTarget {
+    fn destination(self) -> Result<Destination> {
+        let path = match self {
+            SkillTarget::AgentsMd => repo_root()?.join("AGENTS.md"),
+            SkillTarget::AgentsLocal => repo_root()?.join(".agents/skills/ticgit/SKILL.md"),
+            SkillTarget::AgentsGlobal => home()?.join(".agents/skills/ticgit/SKILL.md"),
+            SkillTarget::ClaudeLocal => repo_root()?.join(".claude/skills/ticgit/SKILL.md"),
+            SkillTarget::ClaudeGlobal => home()?.join(".claude/skills/ticgit/SKILL.md"),
+            SkillTarget::OpenCodeLocal => repo_root()?.join(".opencode/skills/ticgit/SKILL.md"),
+            SkillTarget::OpenCodeGlobal => home()?.join(".config/opencode/skills/ticgit/SKILL.md"),
+            SkillTarget::CodexLocal => repo_root()?.join(".codex/skills/ticgit/SKILL.md"),
+            SkillTarget::CodexGlobal => home()?.join(".codex/skills/ticgit/SKILL.md"),
+            SkillTarget::CopilotLocal => repo_root()?.join(".copilot/skills/ticgit/SKILL.md"),
+            SkillTarget::CopilotGlobal => home()?.join(".copilot/skills/ticgit/SKILL.md"),
+            SkillTarget::CursorLocal => repo_root()?.join(".cursor/skills/ticgit/SKILL.md"),
+            SkillTarget::CursorGlobal => home()?.join(".cursor/skills/ticgit/SKILL.md"),
+            SkillTarget::WindsurfLocal => repo_root()?.join(".windsurf/skills/ticgit/SKILL.md"),
+            SkillTarget::WindsurfGlobal => home()?.join(".codeium/windsurf/skills/ticgit/SKILL.md"),
+        };
+        let kind = match self {
+            SkillTarget::AgentsMd => DestinationKind::AgentsMd,
+            _ => DestinationKind::Skill,
+        };
+        Ok(Destination { path, kind })
+    }
+
+    fn prompt_label(self) -> String {
+        match self {
+            SkillTarget::AgentsMd => format!(
+                "AGENTS.md - project instructions ({})",
+                display_path(&self.destination_path_hint())
+            ),
+            SkillTarget::AgentsLocal => {
+                "Agent Skills - shared local .agents/skills format (./.agents/skills/ticgit)"
+                    .to_string()
+            }
+            SkillTarget::AgentsGlobal => {
+                "Agent Skills - shared global .agents/skills format (~/.agents/skills/ticgit)"
+                    .to_string()
+            }
+            SkillTarget::ClaudeLocal => {
+                "Claude Code - local skill (./.claude/skills/ticgit)".to_string()
+            }
+            SkillTarget::ClaudeGlobal => {
+                "Claude Code - global skill (~/.claude/skills/ticgit)".to_string()
+            }
+            SkillTarget::OpenCodeLocal => {
+                "OpenCode - local skill (./.opencode/skills/ticgit)".to_string()
+            }
+            SkillTarget::OpenCodeGlobal => {
+                "OpenCode - global skill (~/.config/opencode/skills/ticgit)".to_string()
+            }
+            SkillTarget::CodexLocal => "Codex - local skill (./.codex/skills/ticgit)".to_string(),
+            SkillTarget::CodexGlobal => "Codex - global skill (~/.codex/skills/ticgit)".to_string(),
+            SkillTarget::CopilotLocal => {
+                "GitHub Copilot - local skill (./.copilot/skills/ticgit)".to_string()
+            }
+            SkillTarget::CopilotGlobal => {
+                "GitHub Copilot - global skill (~/.copilot/skills/ticgit)".to_string()
+            }
+            SkillTarget::CursorLocal => {
+                "Cursor - local skill (./.cursor/skills/ticgit)".to_string()
+            }
+            SkillTarget::CursorGlobal => {
+                "Cursor - global skill (~/.cursor/skills/ticgit)".to_string()
+            }
+            SkillTarget::WindsurfLocal => {
+                "Windsurf - local skill (./.windsurf/skills/ticgit)".to_string()
+            }
+            SkillTarget::WindsurfGlobal => {
+                "Windsurf - global skill (~/.codeium/windsurf/skills/ticgit)".to_string()
+            }
+        }
+    }
+
+    fn destination_path_hint(self) -> PathBuf {
+        match self {
+            SkillTarget::AgentsMd => PathBuf::from("./AGENTS.md"),
+            _ => PathBuf::from("."),
+        }
+    }
+}
+
+impl fmt::Display for SkillTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+fn home() -> Result<PathBuf> {
+    dirs::home_dir().context("could not determine home directory")
+}
+
+fn repo_root() -> Result<PathBuf> {
+    let repo = gix::discover(".").context("finding git repository")?;
+    repo.workdir()
+        .map(PathBuf::from)
+        .or_else(|| repo.git_dir().parent().map(PathBuf::from))
+        .context("could not determine repository root")
+}
+
+fn skill_markdown() -> &'static str {
+    crate::agent_help::MARKDOWN
+}
+
+const AGENTS_START: &str = "<!-- ticgit-agent-start -->";
+const AGENTS_END: &str = "<!-- ticgit-agent-end -->";
+
+fn agents_md_block() -> &'static str {
+    concat!(
+        "<!-- ticgit-agent-start -->\n",
+        "## TicGit\n\n",
+        "This project uses TicGit (`ti`) for Git-native ticket tracking.\n\n",
+        "- Install TicGit from the project README or by using the published release/install instructions.\n",
+        "- Run `ti agent` to learn the TicGit workflow, command examples, and agent practices.\n",
+        "- Prefer `ti list --markdown` and `ti show <id> --markdown` when reading ticket data.\n",
+        "- Use `ti comment`, `ti state`, and `ti close` to record progress and resolution.\n",
+        "<!-- ticgit-agent-end -->",
+    )
+}
+
+fn replace_block(existing: &str, replacement: &str) -> String {
+    let Some(start) = existing.find(AGENTS_START) else {
+        return existing.to_string();
+    };
+    let Some(end_start) = existing.find(AGENTS_END) else {
+        return existing.to_string();
+    };
+    let end = end_start + AGENTS_END.len();
+    format!("{}{}{}", &existing[..start], replacement, &existing[end..])
+}
+
+fn display_path(path: &std::path::Path) -> String {
+    path.display().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replaces_existing_agents_md_block() {
+        let existing =
+            "Intro\n\n<!-- ticgit-agent-start -->\nold\n<!-- ticgit-agent-end -->\nTail\n";
+        let replaced = replace_block(existing, agents_md_block());
+        assert!(replaced.contains("This project uses TicGit"));
+        assert!(!replaced.contains("\nold\n"));
+        assert!(replaced.starts_with("Intro\n\n"));
+        assert!(replaced.ends_with("\nTail\n"));
+    }
+}

--- a/crates/ticgit/src/commands/comment.rs
+++ b/crates/ticgit/src/commands/comment.rs
@@ -32,8 +32,8 @@ pub fn run(args: Args) -> Result<()> {
     let id = resolve_ticket(&store, args.ticket.as_deref())?;
 
     let body = if args.edit || args.body.is_empty() {
-        editor::capture("Ticket comment (lines starting with # are ignored)")?
-            .context("comment cannot be empty")?
+        let ticket = store.load(&id)?;
+        editor::capture_comment(&ticket.title)?.context("comment cannot be empty")?
     } else {
         args.body.join(" ")
     };

--- a/crates/ticgit/src/commands/list.rs
+++ b/crates/ticgit/src/commands/list.rs
@@ -23,6 +23,10 @@ pub struct Args {
     #[arg(long = "all")]
     pub all: bool,
 
+    /// Show all open tickets, without terminal-height truncation.
+    #[arg(long = "open", conflicts_with_all = ["all", "status", "state", "limit"])]
+    pub open: bool,
+
     /// Show only tickets with this tag.
     #[arg(short = 'g', long = "tag")]
     pub tag: Vec<String>,
@@ -71,6 +75,7 @@ impl Default for Args {
             state: None,
             status: None,
             all: false,
+            open: false,
             tag: Vec::new(),
             tag_mode: "all".to_string(),
             assigned: None,
@@ -102,6 +107,7 @@ pub fn run(args: Args) -> Result<()> {
             state: saved.state.clone(),
             status: saved.status.clone(),
             all: saved.all,
+            open: false,
             tag: saved_tags(&saved),
             tag_mode: if saved.tag_match_all { "all" } else { "any" }.to_string(),
             assigned: saved.assigned.clone(),
@@ -160,7 +166,7 @@ pub fn run(args: Args) -> Result<()> {
     };
     let mut tickets = ticgit_lib::query::apply(tickets, &filter);
     let total = tickets.len();
-    let limit = if args.all {
+    let limit = if args.all || args.open {
         0
     } else if args.limit > 0 {
         args.limit
@@ -237,7 +243,7 @@ fn terminal_table_limit(total: usize) -> usize {
 }
 
 fn table_limit_for_rows(total: usize, rows: usize) -> usize {
-    let reserved = if total > rows.saturating_sub(1) { 2 } else { 1 };
+    let reserved = if total > rows.saturating_sub(2) { 3 } else { 2 };
     rows.saturating_sub(reserved).max(1)
 }
 
@@ -254,8 +260,8 @@ mod tests {
 
     #[test]
     fn table_limit_reserves_footer_only_when_rows_are_omitted() {
-        assert_eq!(table_limit_for_rows(3, 10), 9);
-        assert_eq!(table_limit_for_rows(10, 10), 8);
+        assert_eq!(table_limit_for_rows(3, 10), 8);
+        assert_eq!(table_limit_for_rows(10, 10), 7);
         assert_eq!(table_limit_for_rows(10, 2), 1);
     }
 }

--- a/crates/ticgit/src/commands/list.rs
+++ b/crates/ticgit/src/commands/list.rs
@@ -196,6 +196,7 @@ pub fn run(args: Args) -> Result<()> {
             all: args.all,
             subissues: args.subissues,
             limit: args.limit,
+            columns: Vec::new(),
         };
         if let Ok(mut session_state) = State::load() {
             session_state.set_last_filters(&git_dir, saved);

--- a/crates/ticgit/src/commands/list.rs
+++ b/crates/ticgit/src/commands/list.rs
@@ -6,7 +6,7 @@ use crate::commands::{open_store, SessionGitDir};
 use crate::render;
 use crate::session_state::{SavedView, State};
 
-#[derive(Debug, Default, Parser)]
+#[derive(Debug, Parser)]
 pub struct Args {
     /// Load a saved view by name.
     pub view: Option<String>,
@@ -62,6 +62,27 @@ pub struct Args {
     /// Output as Markdown.
     #[arg(long = "markdown", conflicts_with = "json")]
     pub markdown: bool,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        Self {
+            view: None,
+            state: None,
+            status: None,
+            all: false,
+            tag: Vec::new(),
+            tag_mode: "all".to_string(),
+            assigned: None,
+            only_tagged: false,
+            search: None,
+            order: None,
+            subissues: false,
+            limit: 20,
+            json: false,
+            markdown: false,
+        }
+    }
 }
 
 pub fn run(args: Args) -> Result<()> {

--- a/crates/ticgit/src/commands/list.rs
+++ b/crates/ticgit/src/commands/list.rs
@@ -51,8 +51,8 @@ pub struct Args {
     #[arg(long = "subissues")]
     pub subissues: bool,
 
-    /// Maximum number of tickets to show.
-    #[arg(short = 'n', long = "limit", default_value_t = 20)]
+    /// Maximum number of tickets to show. Defaults to available terminal rows.
+    #[arg(short = 'n', long = "limit", default_value_t = 0)]
     pub limit: usize,
 
     /// Output as JSON.
@@ -78,7 +78,7 @@ impl Default for Args {
             search: None,
             order: None,
             subissues: false,
-            limit: 20,
+            limit: 0,
             json: false,
             markdown: false,
         }
@@ -109,7 +109,7 @@ pub fn run(args: Args) -> Result<()> {
             search: saved.search.clone(),
             order: saved.order.clone(),
             subissues: saved.subissues,
-            limit: if saved.limit > 0 { saved.limit } else { 20 },
+            limit: saved.limit,
             json: args.json,
             markdown: args.markdown,
         }
@@ -159,9 +159,20 @@ pub fn run(args: Args) -> Result<()> {
         hide_subissues: !args.subissues,
     };
     let mut tickets = ticgit_lib::query::apply(tickets, &filter);
-    if !args.all && args.limit > 0 {
-        tickets.truncate(args.limit);
+    let total = tickets.len();
+    let limit = if args.all {
+        0
+    } else if args.limit > 0 {
+        args.limit
+    } else if args.json || args.markdown {
+        20
+    } else {
+        terminal_table_limit(total)
+    };
+    if !args.all && limit > 0 {
+        tickets.truncate(limit);
     }
+    let omitted = total.saturating_sub(tickets.len());
 
     // Save last-used filters so `ti views save` can recall them.
     if args.view.is_none() {
@@ -205,16 +216,29 @@ pub fn run(args: Args) -> Result<()> {
     let current = session_state.current_for(&git_dir);
     let users = store.list_users().unwrap_or_default();
     let nicks = render::build_nick_map(&users);
-    println!(
-        "{}",
-        render::tickets_table_with_refs(
-            &tickets,
-            current.as_ref(),
-            &open_ref_lengths,
-            Some(&nicks)
-        )
+    let mut table = render::tickets_table_with_refs(
+        &tickets,
+        current.as_ref(),
+        &open_ref_lengths,
+        Some(&nicks),
     );
+    if omitted > 0 {
+        table.push_str(&format!("... and {omitted} more open issues\n"));
+    }
+    print!("{table}");
     Ok(())
+}
+
+fn terminal_table_limit(total: usize) -> usize {
+    let rows = crossterm::terminal::size()
+        .map(|(_, rows)| rows as usize)
+        .unwrap_or(24);
+    table_limit_for_rows(total, rows)
+}
+
+fn table_limit_for_rows(total: usize, rows: usize) -> usize {
+    let reserved = if total > rows.saturating_sub(1) { 2 } else { 1 };
+    rows.saturating_sub(reserved).max(1)
 }
 
 fn saved_tags(saved: &SavedView) -> Vec<String> {
@@ -222,4 +246,16 @@ fn saved_tags(saved: &SavedView) -> Vec<String> {
         return saved.tags.clone();
     }
     saved.tag.iter().cloned().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_limit_reserves_footer_only_when_rows_are_omitted() {
+        assert_eq!(table_limit_for_rows(3, 10), 9);
+        assert_eq!(table_limit_for_rows(10, 10), 8);
+        assert_eq!(table_limit_for_rows(10, 2), 1);
+    }
 }

--- a/crates/ticgit/src/commands/mod.rs
+++ b/crates/ticgit/src/commands/mod.rs
@@ -1,6 +1,7 @@
 //! Per-subcommand handlers. Each module exposes `Args` (a clap struct)
 //! and `run(args) -> anyhow::Result<()>`.
 
+pub mod agent;
 pub mod assign;
 pub mod checkout;
 pub mod claim;

--- a/crates/ticgit/src/commands/stats.rs
+++ b/crates/ticgit/src/commands/stats.rs
@@ -59,10 +59,16 @@ pub fn run(args: Args) -> Result<()> {
     let mut assignees: BTreeMap<String, usize> = BTreeMap::new();
     let nick_map = crate::render::build_nick_map(&store.list_users().unwrap_or_default());
 
+    let mut recently_opened: Vec<(OffsetDateTime, String, String)> = Vec::new();
     // Collect recently closed tickets (by created_at as proxy for activity).
     let mut recently_closed: Vec<(String, String)> = Vec::new(); // (short_id, title)
 
     for t in &tickets {
+        recently_opened.push((
+            t.created_at,
+            t.id.to_string().chars().take(6).collect(),
+            t.title.clone(),
+        ));
         match t.status {
             ticgit_lib::TicketStatus::Open => open += 1,
             ticgit_lib::TicketStatus::Closed => {
@@ -99,6 +105,7 @@ pub fn run(args: Args) -> Result<()> {
             *assignees.entry(short).or_default() += 1;
         }
     }
+    recently_opened.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
 
     if args.json {
         let states_json: serde_json::Value = states
@@ -188,6 +195,13 @@ pub fn run(args: Args) -> Result<()> {
             }
         }
 
+        if !recently_opened.is_empty() {
+            println!("\n## Recently Opened\n");
+            for (_, id, title) in recently_opened.iter().take(10) {
+                println!("- `{id}` {title}");
+            }
+        }
+
         return Ok(());
     }
 
@@ -236,8 +250,8 @@ pub fn run(args: Args) -> Result<()> {
 
     let assignee_limit = assignee_vec.len().min(3);
 
-    // Recently closed: show if there's vertical room.
-    let recently_closed_limit = if two_col {
+    // Recently opened/closed: show if there's vertical room.
+    let (recently_opened_limit, recently_closed_limit) = if two_col {
         let left_rows = state_vec.len()
             + 1
             + if created_7d > 0 || closed_7d > 0 {
@@ -255,15 +269,35 @@ pub fn run(args: Args) -> Result<()> {
                 0
             };
         let used = left_rows.max(right_rows);
-        avail
-            .saturating_sub(used + 1)
-            .min(recently_closed.len())
-            .min(5)
+        let remaining = avail.saturating_sub(used + 1);
+        if remaining < 3 {
+            (0, 0)
+        } else {
+            let opened = remaining
+                .saturating_sub(1)
+                .min(recently_opened.len())
+                .min(3);
+            let closed = remaining
+                .saturating_sub(opened + usize::from(opened > 0) + 1)
+                .min(recently_closed.len())
+                .min(5);
+            (opened, closed)
+        }
     } else {
-        avail
-            .saturating_sub(state_vec.len() + tag_limit + 10)
-            .min(recently_closed.len())
-            .min(3)
+        let remaining = avail.saturating_sub(state_vec.len() + tag_limit + 10);
+        if remaining < 3 {
+            (0, 0)
+        } else {
+            let opened = remaining
+                .saturating_sub(1)
+                .min(recently_opened.len())
+                .min(3);
+            let closed = remaining
+                .saturating_sub(opened + usize::from(opened > 0) + 1)
+                .min(recently_closed.len())
+                .min(3);
+            (opened, closed)
+        }
     };
 
     // ── Build output ──
@@ -357,6 +391,25 @@ pub fn run(args: Args) -> Result<()> {
             right_lines.push(String::new());
         }
 
+        // Right: Recently Opened
+        if recently_opened_limit > 0 {
+            right_lines.push(format!("{GREEN}{BOLD}  Recently Opened{RESET}"));
+            for (_, id, title) in recently_opened.iter().take(recently_opened_limit) {
+                let max_title = col_width.saturating_sub(12);
+                let display_title = if title.len() > max_title {
+                    format!("{}...", &title[..max_title.saturating_sub(3)])
+                } else {
+                    title.clone()
+                };
+                right_lines.push(format!("    {DIM}{id}{RESET} {display_title}"));
+            }
+            let remaining = recently_opened.len().saturating_sub(recently_opened_limit);
+            if remaining > 0 {
+                right_lines.push(format!("    {DIM}... and {remaining} more{RESET}"));
+            }
+            right_lines.push(String::new());
+        }
+
         // Right: Recently Closed
         if recently_closed_limit > 0 {
             right_lines.push(format!("{RED}{BOLD}  Recently Closed{RESET}"));
@@ -421,6 +474,20 @@ pub fn run(args: Args) -> Result<()> {
             }
             if closed_7d > 0 {
                 println!("    {RED}-{closed_7d}{RESET}{DIM} closed{RESET}");
+            }
+            println!();
+        }
+
+        if recently_opened_limit > 0 {
+            println!("  {GREEN}{BOLD}Recently Opened{RESET}");
+            for (_, id, title) in recently_opened.iter().take(recently_opened_limit) {
+                let max_title = width.saturating_sub(12);
+                let display_title = if title.len() > max_title {
+                    format!("{}...", &title[..max_title.saturating_sub(3)])
+                } else {
+                    title.clone()
+                };
+                println!("    {DIM}{id}{RESET} {display_title}");
             }
             println!();
         }

--- a/crates/ticgit/src/commands/tui.rs
+++ b/crates/ticgit/src/commands/tui.rs
@@ -62,6 +62,7 @@ const DETAIL_WIDTH_PERCENT_STEP: u16 = 5;
 use crate::commands::{open_store, SessionGitDir};
 use crate::editor;
 use crate::session_state::{SavedView, State};
+use crate::timefmt::relative_time;
 
 #[derive(Debug, Parser)]
 pub struct Args {}
@@ -254,7 +255,6 @@ const ORDER_CHOICES: [OrderChoice; 4] = [
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InputKind {
-    Comment,
     Priority,
     Points,
     AddTags,
@@ -1254,7 +1254,7 @@ impl App {
                 "Created",
                 &format!(
                     "{} ago by {}",
-                    relative_date(ticket.created_at, OffsetDateTime::now_utc()),
+                    relative_time(ticket.created_at, OffsetDateTime::now_utc()),
                     created_by_display(ticket)
                 ),
             ),
@@ -1453,7 +1453,7 @@ impl App {
             let mut lines = vec![
                 Line::from(vec![
                     Span::styled(
-                        relative_date(comment.at, OffsetDateTime::now_utc()),
+                        relative_time(comment.at, OffsetDateTime::now_utc()),
                         Style::default()
                             .fg(Color::DarkGray)
                             .add_modifier(Modifier::DIM),
@@ -1484,7 +1484,6 @@ impl App {
         let area = centered_rect(70, kind.modal_height(), frame.area());
         let title = format!("Edit {}", kind.label());
         let help = match kind {
-            InputKind::Comment => "Enter a comment to append.".to_string(),
             InputKind::Priority => format!(
                 "Enter priority. Lower is more important. Empty clears it. {}",
                 self.priority_range_display()
@@ -1670,7 +1669,7 @@ impl App {
                         ),
                         Span::raw(" "),
                         Span::styled(
-                            relative_date(version.at, OffsetDateTime::now_utc()),
+                            relative_time(version.at, OffsetDateTime::now_utc()),
                             Style::default().fg(Color::DarkGray),
                         ),
                     ]))
@@ -1706,7 +1705,7 @@ impl App {
                     version
                         .at
                         .format(&time::format_description::well_known::Rfc3339)
-                        .unwrap_or_else(|_| relative_date(version.at, OffsetDateTime::now_utc())),
+                        .unwrap_or_else(|_| relative_time(version.at, OffsetDateTime::now_utc())),
                     Style::default().fg(Color::DarkGray),
                 ),
                 Span::raw("  "),
@@ -2610,7 +2609,7 @@ impl App {
             }
             KeyCode::Char('c') => {
                 if self.active_tab == TuiTab::Issues {
-                    self.begin_input(InputKind::Comment);
+                    self.add_comment_in_editor(terminal)?;
                 } else {
                     self.set_selected_writeup_status(WriteupStatus::Closed)?;
                 }
@@ -3365,6 +3364,39 @@ impl App {
         Ok(())
     }
 
+    fn add_comment_in_editor(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    ) -> Result<()> {
+        let Some(ticket) = self.selected_ticket() else {
+            self.status = Some("Select a ticket first.".to_string());
+            return Ok(());
+        };
+        let id = ticket.id;
+
+        suspend_terminal(terminal)?;
+        let comment = editor::capture("Ticket comment (lines starting with # are ignored)");
+        resume_terminal(terminal)?;
+
+        match comment? {
+            Some(comment) if !comment.trim().is_empty() => {
+                self.store.add_comment(&id, comment.trim())?;
+                self.status = Some("Added comment.".to_string());
+            }
+            _ => {
+                self.status = Some("Cancelled.".to_string());
+            }
+        }
+
+        self.reload(Some(id))?;
+        if let Some(ticket) = self.selected_ticket() {
+            if !ticket.comments.is_empty() {
+                self.comment_state.select(Some(ticket.comments.len() - 1));
+            }
+        }
+        Ok(())
+    }
+
     fn promote_selected_writeup(&mut self) -> Result<()> {
         let Some(writeup) = self.selected_writeup() else {
             self.status = Some("Select a writeup first.".to_string());
@@ -3560,7 +3592,7 @@ impl App {
                 .and_then(|ticket| ticket.points)
                 .map(|value| value.to_string())
                 .unwrap_or_default(),
-            InputKind::Comment | InputKind::AddTags | InputKind::RemoveTags => String::new(),
+            InputKind::AddTags | InputKind::RemoveTags => String::new(),
         };
         self.mode = Mode::Input(kind);
     }
@@ -3649,15 +3681,6 @@ impl App {
         };
 
         match kind {
-            InputKind::Comment => {
-                let body = self.input.trim();
-                if body.is_empty() {
-                    self.status = Some("Comment cannot be empty.".to_string());
-                    return Ok(false);
-                }
-                self.store.add_comment(&id, body)?;
-                self.status = Some("Added comment.".to_string());
-            }
             InputKind::Priority => {
                 let priority = match parse_optional_i64(&self.input, "priority") {
                     Ok(priority) => priority,
@@ -3690,13 +3713,6 @@ impl App {
         }
 
         self.reload(preferred_after_reload)?;
-        if kind == InputKind::Comment {
-            if let Some(ticket) = self.selected_ticket() {
-                if !ticket.comments.is_empty() {
-                    self.comment_state.select(Some(ticket.comments.len() - 1));
-                }
-            }
-        }
         Ok(true)
     }
 
@@ -4761,7 +4777,6 @@ fn order_choice_index(choice: OrderChoice) -> usize {
 impl InputKind {
     fn label(self) -> &'static str {
         match self {
-            InputKind::Comment => "comment",
             InputKind::Priority => "priority",
             InputKind::Points => "points",
             InputKind::AddTags => "add tags",
@@ -4771,7 +4786,6 @@ impl InputKind {
 
     fn modal_height(self) -> u16 {
         match self {
-            InputKind::Comment => 14,
             InputKind::Priority
             | InputKind::Points
             | InputKind::AddTags
@@ -4989,7 +5003,7 @@ fn writeup_list_line(writeup: &Writeup, width: usize, compact: bool) -> Line<'st
     let meta = vec![
         (
             fit_display(
-                &relative_date(writeup_recent_at(writeup), OffsetDateTime::now_utc()),
+                &relative_time(writeup_recent_at(writeup), OffsetDateTime::now_utc()),
                 LIST_AGE_WIDTH,
             ),
             Style::default()
@@ -5263,7 +5277,7 @@ fn list_meta_display(ticket: &Ticket) -> Vec<(String, Style)> {
     vec![
         (
             fit_display(
-                &relative_date(ticket.created_at, OffsetDateTime::now_utc()),
+                &relative_time(ticket.created_at, OffsetDateTime::now_utc()),
                 LIST_AGE_WIDTH,
             ),
             Style::default()
@@ -5521,7 +5535,7 @@ fn github_author(description: &str) -> Option<&str> {
 }
 
 fn comment_summary_line(comment: &Comment, width: usize) -> Line<'static> {
-    let date = relative_date(comment.at, OffsetDateTime::now_utc());
+    let date = relative_time(comment.at, OffsetDateTime::now_utc());
     let author = comment_author_display(&comment.author);
     let prefix_width =
         UnicodeWidthStr::width(date.as_str()) + 2 + UnicodeWidthStr::width(author.as_str()) + 2;
@@ -5625,7 +5639,7 @@ fn writeup_metadata_lines(writeup: &Writeup, width: usize) -> Vec<Line<'static>>
             label: "Updated",
             value: format!(
                 "{} ago",
-                relative_date(writeup_recent_at(writeup), OffsetDateTime::now_utc())
+                relative_time(writeup_recent_at(writeup), OffsetDateTime::now_utc())
             ),
         },
         MetadataField {
@@ -5896,23 +5910,6 @@ fn status_state_line(ticket: &Ticket) -> Line<'static> {
             Style::default().fg(Color::Green),
         ),
     ])
-}
-
-fn relative_date(then: OffsetDateTime, now: OffsetDateTime) -> String {
-    let seconds = (now - then).whole_seconds().max(0);
-    if seconds < 60 * 60 {
-        return "0d".to_string();
-    }
-    if seconds < 60 * 60 * 24 {
-        return format!("{}h", seconds / (60 * 60));
-    }
-    if seconds < 60 * 60 * 24 * 30 {
-        return format!("{}d", seconds / (60 * 60 * 24));
-    }
-    if seconds < 60 * 60 * 24 * 365 {
-        return format!("{}mo", seconds / (60 * 60 * 24 * 30));
-    }
-    format!("{}y", seconds / (60 * 60 * 24 * 365))
 }
 
 fn new_ticket_field_line(

--- a/crates/ticgit/src/commands/tui.rs
+++ b/crates/ticgit/src/commands/tui.rs
@@ -33,6 +33,7 @@ const LIST_STATE_WIDTH: usize = 2;
 const LIST_AGE_WIDTH: usize = 3;
 const LIST_PRIORITY_WIDTH: usize = 3;
 const COMPACT_LIST_MIN_TITLE_WIDTH: usize = 24;
+const ISSUE_TABLE_MIN_TITLE_WIDTH: usize = 30;
 const ANSI_TAG_COLORS: [Color; 12] = [
     Color::Blue,
     Color::Cyan,
@@ -5379,7 +5380,7 @@ fn issue_columns_for_width(columns: &[IssueColumn], width: usize) -> Vec<IssueCo
         IssueColumn::Closed,
         IssueColumn::Id,
     ] {
-        if issue_columns_min_width(&columns) <= width {
+        if issue_columns_min_width_with_title(&columns, ISSUE_TABLE_MIN_TITLE_WIDTH) <= width {
             break;
         }
         if let Some(idx) = columns.iter().position(|column| *column == removable) {
@@ -5390,10 +5391,10 @@ fn issue_columns_for_width(columns: &[IssueColumn], width: usize) -> Vec<IssueCo
     columns
 }
 
-fn issue_columns_min_width(columns: &[IssueColumn]) -> usize {
+fn issue_columns_min_width_with_title(columns: &[IssueColumn], title_width: usize) -> usize {
     let fixed = columns
         .iter()
-        .map(|column| column.fixed_width().unwrap_or(1))
+        .map(|column| column.fixed_width().unwrap_or(title_width))
         .sum::<usize>();
     fixed + columns.len().saturating_sub(1)
 }
@@ -7044,8 +7045,17 @@ mod tests {
 
         assert_eq!(issue_columns_for_width(&columns, 80), columns);
         assert_eq!(
-            issue_columns_for_width(&columns, 12),
-            vec![IssueColumn::Id, IssueColumn::Closed, IssueColumn::Title]
+            issue_columns_for_width(&columns, 43),
+            vec![
+                IssueColumn::Id,
+                IssueColumn::Closed,
+                IssueColumn::Priority,
+                IssueColumn::Title
+            ]
+        );
+        assert_eq!(
+            issue_columns_for_width(&columns, 38),
+            vec![IssueColumn::Id, IssueColumn::Title]
         );
         assert_eq!(
             issue_columns_for_width(&columns, 3),

--- a/crates/ticgit/src/commands/tui.rs
+++ b/crates/ticgit/src/commands/tui.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::io::{self, Stdout};
 use std::process::Command;
 use std::sync::mpsc::{self, Receiver};
@@ -129,8 +129,48 @@ fn resume_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<
     Ok(())
 }
 
+fn load_closed_times(
+    git_dir: &std::path::Path,
+    tickets: &[Ticket],
+) -> HashMap<uuid::Uuid, OffsetDateTime> {
+    let db_path = git_dir.join("git-meta.sqlite");
+    let Ok(conn) =
+        rusqlite::Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+    else {
+        return HashMap::new();
+    };
+
+    tickets
+        .iter()
+        .filter(|ticket| ticket.status == TicketStatus::Closed)
+        .filter_map(|ticket| {
+            query_closed_at(&conn, ticket.id).map(|closed_at| (ticket.id, closed_at))
+        })
+        .collect()
+}
+
+fn query_closed_at(conn: &rusqlite::Connection, id: uuid::Uuid) -> Option<OffsetDateTime> {
+    let status_key = format!("ticgit:tickets:{id}:status");
+    let closed_by_key = format!("ticgit:tickets:{id}:closed-by");
+    let timestamp_ms: i64 = conn
+        .query_row(
+            "SELECT timestamp \
+             FROM metadata_log \
+             WHERE target_type = 'project' \
+               AND operation != 'remove' \
+               AND ((key = ?1 AND value IN ('\"closed\"', 'closed')) OR key = ?2) \
+             ORDER BY timestamp DESC \
+             LIMIT 1",
+            rusqlite::params![status_key, closed_by_key],
+            |row| row.get(0),
+        )
+        .ok()?;
+    OffsetDateTime::from_unix_timestamp(timestamp_ms / 1000).ok()
+}
+
 struct App {
     store: TicketStore,
+    all_tickets: Vec<Ticket>,
     tickets: Vec<Ticket>,
     visible: Vec<usize>,
     writeups: Vec<Writeup>,
@@ -151,6 +191,9 @@ struct App {
     only_tagged: bool,
     hide_subissues: bool,
     sort_order: Option<SortOrder>,
+    sort_closed_desc: bool,
+    closed_at: HashMap<uuid::Uuid, OffsetDateTime>,
+    issue_columns: Vec<IssueColumn>,
     filter: String,
     tag_filter: BTreeSet<String>,
     tag_filter_match_all: bool,
@@ -159,6 +202,7 @@ struct App {
     link_issue_state: ListState,
     version_state: ListState,
     order_state: ListState,
+    column_state: ListState,
     mode: Mode,
     input: String,
     new_ticket: NewTicketDraft,
@@ -183,6 +227,7 @@ enum ViewMode {
 enum TuiTab {
     Issues,
     Writeups,
+    Dashboard,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -221,6 +266,7 @@ enum Mode {
     Tags,
     ManageTags,
     Order,
+    Columns,
     SavedViews,
     ConfirmDeleteView,
     SaveView,
@@ -246,11 +292,37 @@ enum OrderChoice {
     State,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IssueColumn {
+    Id,
+    Date,
+    Closed,
+    Priority,
+    State,
+    Title,
+    Assignee,
+    Points,
+    Milestone,
+    Tags,
+}
+
 const ORDER_CHOICES: [OrderChoice; 4] = [
     OrderChoice::Priority,
     OrderChoice::DateAsc,
     OrderChoice::DateDesc,
     OrderChoice::State,
+];
+const ISSUE_COLUMN_CHOICES: [IssueColumn; 10] = [
+    IssueColumn::Id,
+    IssueColumn::Date,
+    IssueColumn::Closed,
+    IssueColumn::Priority,
+    IssueColumn::State,
+    IssueColumn::Title,
+    IssueColumn::Assignee,
+    IssueColumn::Points,
+    IssueColumn::Milestone,
+    IssueColumn::Tags,
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -290,6 +362,7 @@ impl App {
             .clamp(DETAIL_WIDTH_PERCENT_MIN, DETAIL_WIDTH_PERCENT_MAX);
         let mut app = Self {
             store,
+            all_tickets: Vec::new(),
             tickets: Vec::new(),
             visible: Vec::new(),
             writeups: Vec::new(),
@@ -310,6 +383,9 @@ impl App {
             only_tagged: false,
             hide_subissues: false,
             sort_order: None,
+            sort_closed_desc: false,
+            closed_at: HashMap::new(),
+            issue_columns: default_issue_columns(),
             filter: String::new(),
             tag_filter: BTreeSet::new(),
             tag_filter_match_all: true,
@@ -318,6 +394,7 @@ impl App {
             link_issue_state: ListState::default(),
             version_state: ListState::default(),
             order_state: ListState::default(),
+            column_state: ListState::default(),
             mode: Mode::Normal,
             input: String::new(),
             new_ticket: NewTicketDraft::default(),
@@ -336,8 +413,11 @@ impl App {
     }
 
     fn reload(&mut self, preferred_id: Option<uuid::Uuid>) -> Result<()> {
+        let tickets = self.store.list()?;
+        self.closed_at = load_closed_times(&self.store.session().repo_git_dir(), &tickets);
+        self.all_tickets = tickets.clone();
         self.tickets = query::apply(
-            self.store.list()?,
+            tickets,
             &Filter {
                 status: self.base_status,
                 state: self.base_state,
@@ -348,7 +428,15 @@ impl App {
                 ..Default::default()
             },
         );
-        if self.sort_order.is_none() {
+        if self.sort_closed_desc {
+            let closed_at = &self.closed_at;
+            self.tickets.sort_by(|a, b| {
+                closed_at_for(closed_at, b)
+                    .cmp(&closed_at_for(closed_at, a))
+                    .then_with(|| b.created_at.cmp(&a.created_at))
+                    .then_with(|| a.id.cmp(&b.id))
+            });
+        } else if self.sort_order.is_none() {
             self.tickets.sort_by(compare_tui_tickets);
         }
         self.apply_filter();
@@ -482,6 +570,7 @@ impl App {
                     ViewMode::Board => self.draw_board(frame, outer[0]),
                 },
                 TuiTab::Writeups => self.draw_writeup_list(frame, outer[0]),
+                TuiTab::Dashboard => self.draw_dashboard(frame, outer[0]),
             }
         }
         if self.sync.is_some() {
@@ -495,6 +584,7 @@ impl App {
             Mode::Tags => self.draw_tags_modal(frame),
             Mode::ManageTags => self.draw_manage_tags_modal(frame),
             Mode::Order => self.draw_order_modal(frame),
+            Mode::Columns => self.draw_columns_modal(frame),
             Mode::SavedViews => self.draw_saved_views_modal(frame),
             Mode::ConfirmDeleteView => self.draw_delete_view_confirm_modal(frame),
             Mode::SaveView => self.draw_save_view_modal(frame),
@@ -624,6 +714,32 @@ impl App {
                     MenuHint {
                         key: "Esc",
                         desc: "cancel",
+                    },
+                ],
+            ),
+            Mode::Columns => (
+                "columns",
+                Some(issue_columns_label(&self.issue_columns)),
+                vec![
+                    MenuHint {
+                        key: "j/k",
+                        desc: "move",
+                    },
+                    MenuHint {
+                        key: "Space",
+                        desc: "toggle",
+                    },
+                    MenuHint {
+                        key: "d",
+                        desc: "default",
+                    },
+                    MenuHint {
+                        key: "V",
+                        desc: "save view",
+                    },
+                    MenuHint {
+                        key: "Esc",
+                        desc: "finish",
                     },
                 ],
             ),
@@ -834,6 +950,25 @@ impl App {
                             desc: "quit",
                         },
                     ]
+                } else if self.active_tab == TuiTab::Dashboard {
+                    vec![
+                        MenuHint {
+                            key: "Tab",
+                            desc: "issues",
+                        },
+                        MenuHint {
+                            key: "r",
+                            desc: "refresh",
+                        },
+                        MenuHint {
+                            key: "S",
+                            desc: "sync",
+                        },
+                        MenuHint {
+                            key: "q",
+                            desc: "quit",
+                        },
+                    ]
                 } else if self.active_tab == TuiTab::Writeups {
                     vec![
                         MenuHint {
@@ -991,6 +1126,10 @@ impl App {
                             desc: "order",
                         },
                         MenuHint {
+                            key: "x",
+                            desc: "columns",
+                        },
+                        MenuHint {
                             key: "1-9",
                             desc: "writeup",
                         },
@@ -1097,27 +1236,41 @@ impl App {
         let title = tabs_title(self.active_tab, &title);
 
         let block = Block::default().borders(Borders::ALL).title(title);
-        let row_width = usize::from(block.inner(area).width)
-            .saturating_sub(UnicodeWidthStr::width(HIGHLIGHT_SYMBOL));
+        let inner = block.inner(area);
+        let row_width =
+            usize::from(inner.width).saturating_sub(UnicodeWidthStr::width(HIGHLIGHT_SYMBOL));
         let compact = self.detail.is_some();
+        let columns = issue_columns_for_width(&self.issue_columns, row_width);
+        let widths = issue_column_widths(&columns, row_width);
 
         let items: Vec<ListItem<'_>> = self
             .visible
             .iter()
             .map(|&idx| {
                 let ticket = &self.tickets[idx];
-                ListItem::new(ticket_list_line(
+                ListItem::new(ticket_table_line(
                     ticket,
+                    &columns,
+                    &widths,
                     row_width,
                     compact,
                     self.store.email(),
+                    self.closed_at.get(&ticket.id).copied(),
                     !self.linked_writeups(ticket.id).is_empty(),
                 ))
             })
             .collect();
 
+        frame.render_widget(block, area);
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Min(0)])
+            .split(inner);
+        frame.render_widget(
+            Paragraph::new(issue_table_header(&columns, &widths, row_width)),
+            chunks[0],
+        );
         let list = List::new(items)
-            .block(block)
             .highlight_style(
                 Style::default()
                     .bg(Color::Rgb(0, 0, 95))
@@ -1126,7 +1279,7 @@ impl App {
             )
             .highlight_symbol(HIGHLIGHT_SYMBOL)
             .highlight_spacing(HighlightSpacing::Always);
-        frame.render_stateful_widget(list, area, &mut self.list_state);
+        frame.render_stateful_widget(list, chunks[1], &mut self.list_state);
     }
 
     fn draw_writeup_list(&mut self, frame: &mut Frame<'_>, area: Rect) {
@@ -1178,6 +1331,21 @@ impl App {
             .highlight_symbol(HIGHLIGHT_SYMBOL)
             .highlight_spacing(HighlightSpacing::Always);
         frame.render_stateful_widget(list, area, &mut self.writeup_state);
+    }
+
+    fn draw_dashboard(&self, frame: &mut Frame<'_>, area: Rect) {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(tabs_title(self.active_tab, "Project stats"));
+        let inner = block.inner(area);
+        let width = usize::from(inner.width);
+        let height = usize::from(inner.height);
+        let stats = DashboardStats::from_tickets(&self.all_tickets);
+        let lines = dashboard_lines(&stats, &self.closed_at, width, height);
+        let dashboard = Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false });
+        frame.render_widget(dashboard, area);
     }
 
     fn draw_board(&mut self, frame: &mut Frame<'_>, area: Rect) {
@@ -1897,6 +2065,75 @@ impl App {
         frame.render_stateful_widget(list, area, &mut self.order_state);
     }
 
+    fn draw_columns_modal(&mut self, frame: &mut Frame<'_>) {
+        let area = centered_rect(64, 17, frame.area());
+        let selected = self
+            .column_state
+            .selected()
+            .unwrap_or(0)
+            .min(ISSUE_COLUMN_CHOICES.len().saturating_sub(1));
+        self.column_state.select(Some(selected));
+
+        let items = ISSUE_COLUMN_CHOICES
+            .iter()
+            .map(|column| {
+                let checked = if self.issue_columns.contains(column) {
+                    "[x]"
+                } else {
+                    "[ ]"
+                };
+                let locked = if *column == IssueColumn::Title {
+                    " required"
+                } else {
+                    ""
+                };
+                ListItem::new(Line::from(vec![
+                    Span::styled(checked, Style::default().fg(Color::Yellow)),
+                    Span::raw(" "),
+                    Span::styled(
+                        fit_display(column.label(), 10),
+                        Style::default()
+                            .fg(Color::Cyan)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::raw(" "),
+                    Span::styled(column.description(), Style::default().fg(Color::Gray)),
+                    Span::styled(locked, Style::default().fg(Color::DarkGray)),
+                ]))
+            })
+            .collect::<Vec<_>>();
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(1)])
+            .split(area);
+        let title = format!("Columns: {}", issue_columns_label(&self.issue_columns));
+        let list = List::new(items)
+            .block(Block::default().borders(Borders::ALL).title(title))
+            .highlight_style(
+                Style::default()
+                    .bg(Color::Rgb(0, 0, 95))
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol(HIGHLIGHT_SYMBOL)
+            .highlight_spacing(HighlightSpacing::Always);
+        let help = Paragraph::new(Line::from(vec![
+            Span::styled("Space", Style::default().fg(Color::Yellow)),
+            Span::raw(" show/hide  "),
+            Span::styled("d", Style::default().fg(Color::Yellow)),
+            Span::raw(" default  "),
+            Span::styled("V", Style::default().fg(Color::Yellow)),
+            Span::raw(" save view  "),
+            Span::styled("Enter/Esc", Style::default().fg(Color::Yellow)),
+            Span::raw(" finish"),
+        ]))
+        .style(Style::default().bg(Color::DarkGray));
+        frame.render_widget(Clear, area);
+        frame.render_stateful_widget(list, chunks[0], &mut self.column_state);
+        frame.render_widget(help, chunks[1]);
+    }
+
     fn draw_saved_views_modal(&mut self, frame: &mut Frame<'_>) {
         let area = centered_rect(78, 20, frame.area());
         let views = self.view_entries();
@@ -2194,6 +2431,15 @@ impl App {
                 lines.push(help_columns(("3", "date desc"), Some(("4", "state"))));
                 lines.push(help_columns(("Esc", "cancel"), None));
             }
+            Mode::Columns => {
+                help_section(&mut lines, "Columns");
+                lines.push(help_columns(
+                    ("j/k", "move column"),
+                    Some(("Space", "show / hide")),
+                ));
+                lines.push(help_columns(("d", "default"), Some(("V", "save view"))));
+                lines.push(help_columns(("Enter", "finish"), Some(("Esc", "finish"))));
+            }
             Mode::SavedViews => {
                 help_section(&mut lines, "Views");
                 lines.push(help_columns(
@@ -2307,6 +2553,11 @@ impl App {
                     Some(("r", "refresh")),
                 ));
             }
+            Mode::Normal if self.active_tab == TuiTab::Dashboard => {
+                help_section(&mut lines, "Dashboard");
+                lines.push(help_columns(("Tab", "issues tab"), Some(("r", "refresh"))));
+                lines.push(help_columns(("S", "sync tickets"), Some(("q", "quit"))));
+            }
             Mode::Normal if self.view == ViewMode::Board && self.detail.is_none() => {
                 help_section(&mut lines, "Navigation");
                 lines.push(help_columns(
@@ -2353,7 +2604,7 @@ impl App {
                     Some(("g", "tag picker")),
                 ));
                 lines.push(help_columns(("o", "order"), Some(("v", "saved views"))));
-                lines.push(help_columns(("V", "save view"), None));
+                lines.push(help_columns(("x", "columns"), Some(("V", "save view"))));
 
                 help_section(&mut lines, "Edit Ticket");
                 lines.push(help_columns(("C", "claim"), Some(("s", "state"))));
@@ -2420,6 +2671,10 @@ impl App {
             }
             Mode::Order => {
                 self.handle_order_key(key)?;
+                false
+            }
+            Mode::Columns => {
+                self.handle_columns_key(key)?;
                 false
             }
             Mode::SavedViews => {
@@ -2522,6 +2777,12 @@ impl App {
             KeyCode::Char('V') => {
                 if self.active_tab == TuiTab::Issues {
                     self.begin_save_view();
+                }
+                false
+            }
+            KeyCode::Char('x') => {
+                if self.active_tab == TuiTab::Issues && self.view == ViewMode::List {
+                    self.begin_columns();
                 }
                 false
             }
@@ -2755,6 +3016,24 @@ impl App {
             KeyCode::Char('2') => self.apply_order_choice(OrderChoice::DateAsc)?,
             KeyCode::Char('3') => self.apply_order_choice(OrderChoice::DateDesc)?,
             KeyCode::Char('4') => self.apply_order_choice(OrderChoice::State)?,
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_columns_key(&mut self, key: KeyEvent) -> Result<()> {
+        match key.code {
+            KeyCode::Enter | KeyCode::Esc => {
+                self.mode = Mode::Normal;
+            }
+            KeyCode::Down | KeyCode::Char('j') => self.next_column_choice(),
+            KeyCode::Up | KeyCode::Char('k') => self.previous_column_choice(),
+            KeyCode::Char(' ') => self.toggle_selected_column(),
+            KeyCode::Char('d') => {
+                self.issue_columns = default_issue_columns();
+                self.status = Some("Restored default columns.".to_string());
+            }
+            KeyCode::Char('V') => self.begin_save_view(),
             _ => {}
         }
         Ok(())
@@ -3012,6 +3291,16 @@ impl App {
         self.mode = Mode::Order;
     }
 
+    fn begin_columns(&mut self) {
+        let selected = self
+            .column_state
+            .selected()
+            .unwrap_or(0)
+            .min(ISSUE_COLUMN_CHOICES.len().saturating_sub(1));
+        self.column_state.select(Some(selected));
+        self.mode = Mode::Columns;
+    }
+
     fn begin_saved_views(&mut self) {
         let views = self.view_entries();
         let selected = self
@@ -3102,10 +3391,19 @@ impl App {
             assigned: self.assigned_filter.clone(),
             only_tagged: self.only_tagged,
             search: optional_trimmed(&self.filter).map(ToString::to_string),
-            order: Some(self.current_order_choice().spec().to_string()),
+            order: Some(if self.sort_closed_desc {
+                "closed.desc".to_string()
+            } else {
+                self.current_order_choice().spec().to_string()
+            }),
             all: self.base_status.is_none() && self.base_state.is_none(),
             subissues: !self.hide_subissues,
             limit: 0,
+            columns: self
+                .issue_columns
+                .iter()
+                .map(|column| column.as_str().to_string())
+                .collect(),
         }
     }
 
@@ -3182,13 +3480,16 @@ impl App {
         self.filter = view.search.clone().unwrap_or_default();
         self.tag_filter = saved_view_tags(view).into_iter().collect();
         self.tag_filter_match_all = view.tag_match_all;
+        self.sort_closed_desc = matches!(view.order.as_deref(), Some("closed.desc" | "closed"));
         self.sort_order = match view.order.as_deref() {
+            Some("closed.desc" | "closed") => None,
             Some(spec) => Some(
                 SortOrder::parse(spec)
                     .ok_or_else(|| anyhow::anyhow!("unknown sort order `{spec}`"))?,
             ),
             None => None,
         };
+        self.issue_columns = saved_issue_columns(view);
         self.detail = None;
         self.writeup_detail = None;
         self.comments_mode = false;
@@ -3207,6 +3508,8 @@ impl App {
         self.only_tagged = false;
         self.hide_subissues = false;
         self.sort_order = None;
+        self.sort_closed_desc = false;
+        self.issue_columns = default_issue_columns();
         self.filter.clear();
         self.tag_filter.clear();
         self.tag_filter_match_all = true;
@@ -3373,9 +3676,10 @@ impl App {
             return Ok(());
         };
         let id = ticket.id;
+        let title = ticket.title.clone();
 
         suspend_terminal(terminal)?;
-        let comment = editor::capture("Ticket comment (lines starting with # are ignored)");
+        let comment = editor::capture_comment(&title);
         resume_terminal(terminal)?;
 
         match comment? {
@@ -3482,6 +3786,7 @@ impl App {
                 };
                 self.jump_to_ticket(ticket_id);
             }
+            TuiTab::Dashboard => {}
         }
     }
 
@@ -4119,6 +4424,47 @@ impl App {
         self.order_state.select(Some(previous));
     }
 
+    fn next_column_choice(&mut self) {
+        let selected = self.column_state.selected().unwrap_or(0);
+        self.column_state
+            .select(Some((selected + 1) % ISSUE_COLUMN_CHOICES.len()));
+    }
+
+    fn previous_column_choice(&mut self) {
+        let selected = self.column_state.selected().unwrap_or(0);
+        let previous = selected
+            .checked_sub(1)
+            .unwrap_or_else(|| ISSUE_COLUMN_CHOICES.len() - 1);
+        self.column_state.select(Some(previous));
+    }
+
+    fn toggle_selected_column(&mut self) {
+        let selected = self.column_state.selected().unwrap_or(0);
+        let Some(column) = ISSUE_COLUMN_CHOICES.get(selected).copied() else {
+            return;
+        };
+        if column == IssueColumn::Title {
+            self.status = Some("Title column is required.".to_string());
+            return;
+        }
+        if let Some(idx) = self
+            .issue_columns
+            .iter()
+            .position(|candidate| *candidate == column)
+        {
+            self.issue_columns.remove(idx);
+        } else {
+            self.issue_columns.push(column);
+            self.issue_columns
+                .sort_by_key(|column| issue_column_index(*column));
+        }
+        if !self.issue_columns.contains(&IssueColumn::Title) {
+            self.issue_columns.push(IssueColumn::Title);
+            self.issue_columns
+                .sort_by_key(|column| issue_column_index(*column));
+        }
+    }
+
     fn apply_selected_order(&mut self) -> Result<()> {
         let selected = self.order_state.selected().unwrap_or(0);
         let choice = ORDER_CHOICES
@@ -4304,6 +4650,9 @@ impl App {
             self.next_writeup();
             return;
         }
+        if self.active_tab == TuiTab::Dashboard {
+            return;
+        }
         if self.visible.is_empty() {
             return;
         }
@@ -4316,6 +4665,9 @@ impl App {
     fn previous(&mut self) {
         if self.active_tab == TuiTab::Writeups {
             self.previous_writeup();
+            return;
+        }
+        if self.active_tab == TuiTab::Dashboard {
             return;
         }
         if self.visible.is_empty() {
@@ -4403,7 +4755,8 @@ impl App {
                 self.view = ViewMode::List;
                 TuiTab::Writeups
             }
-            TuiTab::Writeups => TuiTab::Issues,
+            TuiTab::Writeups => TuiTab::Dashboard,
+            TuiTab::Dashboard => TuiTab::Issues,
         };
     }
 
@@ -4663,6 +5016,7 @@ impl App {
                     writeup.tags.clone(),
                 ))
             }
+            TuiTab::Dashboard => None,
         }
     }
 
@@ -4900,6 +5254,16 @@ fn compare_tui_tickets(a: &Ticket, b: &Ticket) -> std::cmp::Ordering {
         .then_with(|| a.id.cmp(&b.id))
 }
 
+fn closed_at_for(
+    closed_at: &HashMap<uuid::Uuid, OffsetDateTime>,
+    ticket: &Ticket,
+) -> OffsetDateTime {
+    closed_at
+        .get(&ticket.id)
+        .copied()
+        .unwrap_or(ticket.created_at)
+}
+
 fn priority_sort_key(priority: Option<i64>) -> (u8, i64) {
     match priority {
         Some(value) => (0, value),
@@ -4955,7 +5319,12 @@ fn tabs_title(active: TuiTab, title: &str) -> String {
     } else {
         " writeups "
     };
-    format!("{issues} {writeups}  {title}")
+    let dashboard = if active == TuiTab::Dashboard {
+        "[dashboard]"
+    } else {
+        " dashboard "
+    };
+    format!("{issues} {writeups} {dashboard}  {title}")
 }
 
 fn ticket_list_line(
@@ -4991,6 +5360,236 @@ fn ticket_list_line(
         width,
         has_writeups.then(|| ("[w]".to_string(), Style::default().fg(Color::Yellow))),
     )
+}
+
+fn issue_columns_for_width(columns: &[IssueColumn], width: usize) -> Vec<IssueColumn> {
+    let mut columns = columns.to_vec();
+    if !columns.contains(&IssueColumn::Title) {
+        columns.push(IssueColumn::Title);
+    }
+
+    for removable in [
+        IssueColumn::Tags,
+        IssueColumn::Milestone,
+        IssueColumn::Points,
+        IssueColumn::Assignee,
+        IssueColumn::Priority,
+        IssueColumn::State,
+        IssueColumn::Date,
+        IssueColumn::Closed,
+        IssueColumn::Id,
+    ] {
+        if issue_columns_min_width(&columns) <= width {
+            break;
+        }
+        if let Some(idx) = columns.iter().position(|column| *column == removable) {
+            columns.remove(idx);
+        }
+    }
+
+    columns
+}
+
+fn issue_columns_min_width(columns: &[IssueColumn]) -> usize {
+    let fixed = columns
+        .iter()
+        .map(|column| column.fixed_width().unwrap_or(1))
+        .sum::<usize>();
+    fixed + columns.len().saturating_sub(1)
+}
+
+fn issue_column_widths(columns: &[IssueColumn], width: usize) -> Vec<usize> {
+    let fixed = columns
+        .iter()
+        .filter_map(|column| column.fixed_width())
+        .sum::<usize>();
+    let gaps = columns.len().saturating_sub(1);
+    let title_width = width.saturating_sub(fixed + gaps).max(1);
+    columns
+        .iter()
+        .map(|column| column.fixed_width().unwrap_or(title_width))
+        .collect()
+}
+
+fn issue_table_header(columns: &[IssueColumn], widths: &[usize], width: usize) -> Line<'static> {
+    let mut spans = vec![Span::raw(
+        " ".repeat(UnicodeWidthStr::width(HIGHLIGHT_SYMBOL)),
+    )];
+    for (idx, (column, column_width)) in columns.iter().zip(widths).enumerate() {
+        if idx > 0 {
+            spans.push(Span::raw(" "));
+        }
+        spans.push(Span::styled(
+            fit_display(column.label(), *column_width),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    let used = spans_width(&spans);
+    if used < width {
+        spans.push(Span::raw(" ".repeat(width - used)));
+    }
+    Line::from(spans)
+}
+
+fn ticket_table_line(
+    ticket: &Ticket,
+    columns: &[IssueColumn],
+    widths: &[usize],
+    width: usize,
+    _compact: bool,
+    current_user: &str,
+    closed_at: Option<OffsetDateTime>,
+    has_writeups: bool,
+) -> Line<'static> {
+    let mut spans = Vec::new();
+    for (idx, (column, column_width)) in columns.iter().zip(widths).enumerate() {
+        if idx > 0 {
+            spans.push(Span::raw(" "));
+        }
+        match column {
+            IssueColumn::Id => push_issue_id_column(
+                &mut spans,
+                ticket,
+                *column_width,
+                ticket.assigned.as_deref() == Some(current_user),
+            ),
+            IssueColumn::Tags => push_issue_tags_column(&mut spans, &ticket.tags, *column_width),
+            _ => {
+                let (value, style) = issue_column_value(ticket, *column, closed_at, current_user);
+                spans.push(Span::styled(fit_display(&value, *column_width), style));
+            }
+        }
+    }
+
+    if has_writeups {
+        push_right_indicator(
+            &mut spans,
+            Some(("[w]".to_string(), Style::default().fg(Color::Yellow))),
+            width,
+        );
+    }
+
+    Line::from(spans)
+}
+
+fn push_issue_id_column(
+    spans: &mut Vec<Span<'static>>,
+    ticket: &Ticket,
+    width: usize,
+    assigned_to_current_user: bool,
+) {
+    let short_id = ticket
+        .short_id()
+        .chars()
+        .take(LIST_ID_WIDTH)
+        .collect::<String>();
+    let id = truncate_display(&short_id, width);
+    let id_width = UnicodeWidthStr::width(id.as_str());
+    let star_width = width.saturating_sub(id_width).min(1);
+    let star = if assigned_to_current_user { "*" } else { " " };
+    let padding_width = width.saturating_sub(id_width + star_width);
+
+    spans.push(Span::styled(id, Style::default().fg(Color::DarkGray)));
+    spans.push(Span::styled(
+        truncate_display(star, star_width),
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    ));
+    if padding_width > 0 {
+        spans.push(Span::raw(" ".repeat(padding_width)));
+    }
+}
+
+fn push_issue_tags_column(spans: &mut Vec<Span<'static>>, tags: &BTreeSet<String>, width: usize) {
+    let tag_spans = tag_spans(tags, width);
+    let tag_width = spans_width(&tag_spans);
+    spans.extend(tag_spans);
+    if tag_width < width {
+        spans.push(Span::raw(" ".repeat(width - tag_width)));
+    }
+}
+
+fn issue_column_value(
+    ticket: &Ticket,
+    column: IssueColumn,
+    closed_at: Option<OffsetDateTime>,
+    current_user: &str,
+) -> (String, Style) {
+    match column {
+        IssueColumn::Id => (
+            ticket.short_id().chars().take(LIST_ID_WIDTH).collect(),
+            Style::default().fg(Color::DarkGray),
+        ),
+        IssueColumn::Date => (
+            relative_time(ticket.created_at, OffsetDateTime::now_utc()),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::DIM),
+        ),
+        IssueColumn::Closed => (
+            closed_at
+                .map(|at| relative_time(at, OffsetDateTime::now_utc()))
+                .unwrap_or_default(),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::DIM),
+        ),
+        IssueColumn::Priority => (
+            ticket
+                .priority
+                .map(|priority| format!("p{priority}"))
+                .unwrap_or_default(),
+            Style::default().fg(Color::Magenta),
+        ),
+        IssueColumn::State => (
+            state_abbrev(ticket.state).to_string(),
+            state_abbrev_style(ticket.state),
+        ),
+        IssueColumn::Title => (
+            flatten_display(&ticket.title),
+            Style::default().fg(Color::Reset),
+        ),
+        IssueColumn::Assignee => (
+            ticket
+                .assigned
+                .as_deref()
+                .map(short_assignee)
+                .unwrap_or_default(),
+            if ticket.assigned.as_deref() == Some(current_user) {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::Gray)
+            },
+        ),
+        IssueColumn::Points => (
+            ticket
+                .points
+                .map(|points| points.to_string())
+                .unwrap_or_default(),
+            Style::default().fg(Color::LightBlue),
+        ),
+        IssueColumn::Milestone => (
+            ticket.milestone.clone().unwrap_or_default(),
+            Style::default().fg(Color::LightCyan),
+        ),
+        IssueColumn::Tags => (
+            ticket.tags.iter().cloned().collect::<Vec<_>>().join(","),
+            Style::default().fg(Color::Yellow),
+        ),
+    }
+}
+
+fn short_assignee(assignee: &str) -> String {
+    assignee
+        .split_once('@')
+        .map(|(local, _)| local)
+        .unwrap_or(assignee)
+        .to_string()
 }
 
 fn writeup_list_line(writeup: &Writeup, width: usize, compact: bool) -> Line<'static> {
@@ -5047,6 +5646,317 @@ fn writeup_list_line(writeup: &Writeup, width: usize, compact: bool) -> Line<'st
         width,
         issue_indicator,
     )
+}
+
+struct DashboardStats {
+    total: usize,
+    open: usize,
+    closed: usize,
+    with_comments: usize,
+    created_7d: usize,
+    states: Vec<(String, usize)>,
+    tags: Vec<(String, usize)>,
+    assignees: Vec<(String, usize)>,
+    recently_opened: Vec<(uuid::Uuid, String)>,
+    closed_tickets: Vec<(uuid::Uuid, OffsetDateTime, String)>,
+}
+
+impl DashboardStats {
+    fn from_tickets(tickets: &[Ticket]) -> Self {
+        let now = OffsetDateTime::now_utc();
+        let week_ago = now - time::Duration::days(7);
+        let mut open = 0;
+        let mut closed = 0;
+        let mut with_comments = 0;
+        let mut created_7d = 0;
+        let mut states = BTreeMap::<String, usize>::new();
+        let mut tags = BTreeMap::<String, usize>::new();
+        let mut assignees = BTreeMap::<String, usize>::new();
+        let mut recently_opened = Vec::new();
+        let mut closed_tickets = Vec::new();
+
+        for ticket in tickets {
+            match ticket.status {
+                TicketStatus::Open => open += 1,
+                TicketStatus::Closed => {
+                    closed += 1;
+                    closed_tickets.push((ticket.id, ticket.created_at, ticket.title.clone()));
+                }
+            }
+            if !ticket.comments.is_empty() {
+                with_comments += 1;
+            }
+            if ticket.created_at >= week_ago {
+                created_7d += 1;
+            }
+            *states.entry(ticket.state.as_str().to_string()).or_default() += 1;
+            for tag in &ticket.tags {
+                *tags.entry(tag.clone()).or_default() += 1;
+            }
+            if let Some(assigned) = &ticket.assigned {
+                *assignees.entry(short_assignee(assigned)).or_default() += 1;
+            }
+            recently_opened.push((ticket.id, ticket.title.clone()));
+        }
+
+        let sort_counts = |map: BTreeMap<String, usize>| {
+            let mut values = map.into_iter().collect::<Vec<_>>();
+            values.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+            values
+        };
+        recently_opened.sort_by(|a, b| {
+            ticket_created_at(tickets, b.0)
+                .cmp(&ticket_created_at(tickets, a.0))
+                .then_with(|| a.0.cmp(&b.0))
+        });
+
+        Self {
+            total: tickets.len(),
+            open,
+            closed,
+            with_comments,
+            created_7d,
+            states: sort_counts(states),
+            tags: sort_counts(tags),
+            assignees: sort_counts(assignees),
+            recently_opened,
+            closed_tickets,
+        }
+    }
+}
+
+fn ticket_created_at(tickets: &[Ticket], id: uuid::Uuid) -> OffsetDateTime {
+    tickets
+        .iter()
+        .find(|ticket| ticket.id == id)
+        .map(|ticket| ticket.created_at)
+        .unwrap_or(OffsetDateTime::UNIX_EPOCH)
+}
+
+fn dashboard_lines(
+    stats: &DashboardStats,
+    closed_at: &HashMap<uuid::Uuid, OffsetDateTime>,
+    width: usize,
+    height: usize,
+) -> Vec<Line<'static>> {
+    if stats.total == 0 {
+        return vec![Line::from(Span::styled(
+            "No tickets.",
+            Style::default().fg(Color::DarkGray),
+        ))];
+    }
+
+    let now = OffsetDateTime::now_utc();
+    let week_ago = now - time::Duration::days(7);
+    let mut recently_closed = stats
+        .closed_tickets
+        .iter()
+        .map(|(id, fallback, title)| {
+            let closed = closed_at.get(id).copied().unwrap_or(*fallback);
+            (*id, closed, title.clone())
+        })
+        .collect::<Vec<_>>();
+    recently_closed.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    let closed_7d = recently_closed
+        .iter()
+        .filter(|(_, closed, _)| *closed >= week_ago)
+        .count();
+
+    let mut lines = Vec::new();
+    lines.push(Line::from(vec![
+        Span::styled(
+            stats.total.to_string(),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" tickets  ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            stats.open.to_string(),
+            Style::default()
+                .fg(Color::LightGreen)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" open  ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            stats.closed.to_string(),
+            Style::default()
+                .fg(Color::LightRed)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" closed", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!("  {} with comments", stats.with_comments),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled(
+            format!("+{}", stats.created_7d),
+            Style::default().fg(Color::LightGreen),
+        ),
+        Span::styled(" opened  ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!("-{closed_7d}"),
+            Style::default().fg(Color::LightRed),
+        ),
+        Span::styled(
+            " closed in the last 7d",
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]));
+    lines.push(Line::raw(""));
+
+    push_count_section(
+        &mut lines,
+        "States",
+        &stats.states,
+        Color::Cyan,
+        width,
+        height,
+    );
+    push_count_section(
+        &mut lines,
+        "Top Tags",
+        &stats.tags,
+        Color::Magenta,
+        width,
+        height,
+    );
+    push_count_section(
+        &mut lines,
+        "Assignees",
+        &stats.assignees,
+        Color::LightGreen,
+        width,
+        height,
+    );
+    push_ticket_section(
+        &mut lines,
+        "Recently Opened",
+        &stats
+            .recently_opened
+            .iter()
+            .map(|(id, title)| (*id, title.clone()))
+            .collect::<Vec<_>>(),
+        Color::LightGreen,
+        width,
+        height,
+    );
+    push_ticket_section(
+        &mut lines,
+        "Recently Closed",
+        &recently_closed
+            .iter()
+            .map(|(id, _, title)| (*id, title.clone()))
+            .collect::<Vec<_>>(),
+        Color::LightRed,
+        width,
+        height,
+    );
+
+    lines.truncate(height.max(1));
+    lines
+}
+
+fn push_count_section(
+    lines: &mut Vec<Line<'static>>,
+    title: &'static str,
+    rows: &[(String, usize)],
+    color: Color,
+    width: usize,
+    height: usize,
+) {
+    if rows.is_empty() || lines.len() + 3 > height {
+        return;
+    }
+    let remaining = height.saturating_sub(lines.len() + 2);
+    if remaining == 0 {
+        return;
+    }
+    let limit = rows.len().min(remaining.min(5));
+    lines.push(Line::from(Span::styled(
+        title,
+        Style::default().fg(color).add_modifier(Modifier::BOLD),
+    )));
+    let max = rows.iter().map(|(_, count)| *count).max().unwrap_or(1);
+    let bar_width = width.saturating_sub(22).min(28);
+    for (label, count) in rows.iter().take(limit) {
+        lines.push(count_line(label, *count, max, color, bar_width));
+    }
+    if rows.len() > limit && lines.len() < height {
+        lines.push(Line::from(Span::styled(
+            format!("... and {} more", rows.len() - limit),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+    if lines.len() < height {
+        lines.push(Line::raw(""));
+    }
+}
+
+fn count_line(
+    label: &str,
+    count: usize,
+    max: usize,
+    color: Color,
+    bar_width: usize,
+) -> Line<'static> {
+    let filled = if max == 0 || bar_width == 0 {
+        0
+    } else {
+        ((count as f64 / max as f64) * bar_width as f64)
+            .round()
+            .max(1.0) as usize
+    }
+    .min(bar_width);
+    Line::from(vec![
+        Span::styled(fit_display(label, 14), Style::default().fg(color)),
+        Span::raw(" "),
+        Span::styled(format!("{count:>3}"), Style::default().fg(Color::Gray)),
+        Span::raw(" "),
+        Span::styled(" ".repeat(filled), Style::default().bg(color)),
+    ])
+}
+
+fn push_ticket_section(
+    lines: &mut Vec<Line<'static>>,
+    title: &'static str,
+    rows: &[(uuid::Uuid, String)],
+    color: Color,
+    width: usize,
+    height: usize,
+) {
+    if rows.is_empty() || lines.len() + 3 > height {
+        return;
+    }
+    let remaining = height.saturating_sub(lines.len() + 2);
+    if remaining == 0 {
+        return;
+    }
+    let limit = rows.len().min(remaining.min(5));
+    lines.push(Line::from(Span::styled(
+        title,
+        Style::default().fg(color).add_modifier(Modifier::BOLD),
+    )));
+    let title_width = width.saturating_sub(10);
+    for (id, title) in rows.iter().take(limit) {
+        let short = id.to_string().chars().take(6).collect::<String>();
+        lines.push(Line::from(vec![
+            Span::styled(short, Style::default().fg(Color::DarkGray)),
+            Span::raw(" "),
+            Span::raw(truncate_display(&flatten_display(title), title_width)),
+        ]));
+    }
+    if rows.len() > limit && lines.len() < height {
+        lines.push(Line::from(Span::styled(
+            format!("... and {} more", rows.len() - limit),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+    if lines.len() < height {
+        lines.push(Line::raw(""));
+    }
 }
 
 fn writeup_recent_at(writeup: &Writeup) -> OffsetDateTime {
@@ -5470,6 +6380,7 @@ fn builtin_views(current_user: &str) -> Vec<ViewEntry> {
                 status: Some("open".to_string()),
                 subissues: true,
                 tag_match_all: true,
+                columns: default_issue_column_names(),
                 ..Default::default()
             },
             kind: ViewKind::BuiltIn,
@@ -5481,6 +6392,7 @@ fn builtin_views(current_user: &str) -> Vec<ViewEntry> {
                 assigned: Some(current_user.to_string()),
                 subissues: true,
                 tag_match_all: true,
+                columns: default_issue_column_names(),
                 ..Default::default()
             },
             kind: ViewKind::BuiltIn,
@@ -5489,9 +6401,16 @@ fn builtin_views(current_user: &str) -> Vec<ViewEntry> {
             name: "Recently Closed".to_string(),
             view: SavedView {
                 status: Some("closed".to_string()),
-                order: Some("created.desc".to_string()),
+                order: Some("closed.desc".to_string()),
                 subissues: true,
                 tag_match_all: true,
+                columns: vec![
+                    "id".to_string(),
+                    "closed".to_string(),
+                    "state".to_string(),
+                    "priority".to_string(),
+                    "title".to_string(),
+                ],
                 ..Default::default()
             },
             kind: ViewKind::BuiltIn,
@@ -5502,11 +6421,137 @@ fn builtin_views(current_user: &str) -> Vec<ViewEntry> {
                 all: true,
                 subissues: true,
                 tag_match_all: true,
+                columns: default_issue_column_names(),
                 ..Default::default()
             },
             kind: ViewKind::BuiltIn,
         },
     ]
+}
+
+fn default_issue_columns() -> Vec<IssueColumn> {
+    vec![
+        IssueColumn::Id,
+        IssueColumn::Date,
+        IssueColumn::State,
+        IssueColumn::Priority,
+        IssueColumn::Title,
+        IssueColumn::Tags,
+    ]
+}
+
+fn default_issue_column_names() -> Vec<String> {
+    default_issue_columns()
+        .into_iter()
+        .map(|column| column.as_str().to_string())
+        .collect()
+}
+
+fn saved_issue_columns(view: &SavedView) -> Vec<IssueColumn> {
+    let mut columns = view
+        .columns
+        .iter()
+        .filter_map(|column| IssueColumn::parse(column))
+        .collect::<Vec<_>>();
+    if columns.is_empty() {
+        columns = default_issue_columns();
+    }
+    if !columns.contains(&IssueColumn::Title) {
+        columns.push(IssueColumn::Title);
+    }
+    columns
+}
+
+impl IssueColumn {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "id" | "ticid" => Some(Self::Id),
+            "date" | "created" | "dt" => Some(Self::Date),
+            "closed" | "closed_at" | "closed-at" => Some(Self::Closed),
+            "priority" | "prio" | "p" => Some(Self::Priority),
+            "state" => Some(Self::State),
+            "title" => Some(Self::Title),
+            "assignee" | "assigned" => Some(Self::Assignee),
+            "points" | "pts" => Some(Self::Points),
+            "milestone" => Some(Self::Milestone),
+            "tags" => Some(Self::Tags),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Id => "id",
+            Self::Date => "date",
+            Self::Closed => "closed",
+            Self::Priority => "priority",
+            Self::State => "state",
+            Self::Title => "title",
+            Self::Assignee => "assignee",
+            Self::Points => "points",
+            Self::Milestone => "milestone",
+            Self::Tags => "tags",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Id => "Id",
+            Self::Date => "Dt",
+            Self::Closed => "Cls",
+            Self::Priority => "P",
+            Self::State => "St",
+            Self::Title => "Title",
+            Self::Assignee => "Assignee",
+            Self::Points => "Pts",
+            Self::Milestone => "Milestone",
+            Self::Tags => "Tags",
+        }
+    }
+
+    fn description(self) -> &'static str {
+        match self {
+            Self::Id => "ticket id and claimed marker",
+            Self::Date => "created relative date",
+            Self::Closed => "closed relative date",
+            Self::Priority => "priority",
+            Self::State => "lifecycle state",
+            Self::Title => "ticket title",
+            Self::Assignee => "assigned user",
+            Self::Points => "estimate points",
+            Self::Milestone => "milestone",
+            Self::Tags => "colored tags",
+        }
+    }
+
+    fn fixed_width(self) -> Option<usize> {
+        match self {
+            Self::Id => Some(LIST_ID_WIDTH + 1),
+            Self::Date | Self::Closed => Some(LIST_AGE_WIDTH),
+            Self::Priority => Some(LIST_PRIORITY_WIDTH),
+            Self::State => Some(LIST_STATE_WIDTH),
+            Self::Title => None,
+            Self::Assignee => Some(8),
+            Self::Points => Some(3),
+            Self::Milestone => Some(10),
+            Self::Tags => Some(20),
+        }
+    }
+}
+
+fn issue_column_index(column: IssueColumn) -> usize {
+    ISSUE_COLUMN_CHOICES
+        .iter()
+        .position(|candidate| *candidate == column)
+        .unwrap_or(usize::MAX)
+}
+
+fn issue_columns_label(columns: &[IssueColumn]) -> String {
+    columns
+        .iter()
+        .map(|column| column.label())
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn optional_trimmed(raw: &str) -> Option<&str> {
@@ -5962,4 +7007,79 @@ fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
         ])
         .split(popup_layout[1]);
     horizontal[1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn saved_issue_columns_fall_back_to_default_and_keep_title() {
+        let default = saved_issue_columns(&SavedView::default());
+        assert_eq!(default, default_issue_columns());
+
+        let custom = saved_issue_columns(&SavedView {
+            columns: vec!["closed".to_string(), "priority".to_string()],
+            ..Default::default()
+        });
+        assert_eq!(
+            custom,
+            vec![
+                IssueColumn::Closed,
+                IssueColumn::Priority,
+                IssueColumn::Title
+            ]
+        );
+    }
+
+    #[test]
+    fn issue_columns_drop_optional_fields_to_fit_width() {
+        let columns = vec![
+            IssueColumn::Id,
+            IssueColumn::Closed,
+            IssueColumn::Priority,
+            IssueColumn::Title,
+            IssueColumn::Tags,
+        ];
+
+        assert_eq!(issue_columns_for_width(&columns, 80), columns);
+        assert_eq!(
+            issue_columns_for_width(&columns, 12),
+            vec![IssueColumn::Id, IssueColumn::Closed, IssueColumn::Title]
+        );
+        assert_eq!(
+            issue_columns_for_width(&columns, 3),
+            vec![IssueColumn::Title]
+        );
+    }
+
+    #[test]
+    fn recently_closed_builtin_uses_closed_column_and_order() {
+        let views = builtin_views("me@example.com");
+        let recent = views
+            .iter()
+            .find(|view| view.name == "Recently Closed")
+            .unwrap();
+
+        assert_eq!(recent.view.order.as_deref(), Some("closed.desc"));
+        assert!(recent.view.columns.contains(&"closed".to_string()));
+        assert!(!recent.view.columns.contains(&"date".to_string()));
+    }
+
+    #[test]
+    fn id_column_reserves_space_for_claimed_marker() {
+        assert_eq!(IssueColumn::Id.fixed_width(), Some(4));
+    }
+
+    #[test]
+    fn tag_column_uses_colored_tag_spans() {
+        let mut tags = BTreeSet::new();
+        tags.insert("bug".to_string());
+
+        let mut spans = Vec::new();
+        push_issue_tags_column(&mut spans, &tags, 8);
+
+        assert_eq!(spans_width(&spans), 8);
+        assert!(spans.iter().any(|span| span.content.as_ref() == "bug"));
+    }
 }

--- a/crates/ticgit/src/editor.rs
+++ b/crates/ticgit/src/editor.rs
@@ -15,6 +15,16 @@ pub fn capture_with_initial(prompt: &str, initial: &str) -> Result<Option<String
     soe::capture_with_initial(prompt, initial)
 }
 
+/// Open the editor to capture a ticket comment with ticket context in the
+/// commented prompt block.
+pub fn capture_comment(title: &str) -> Result<Option<String>> {
+    capture(&comment_prompt(title))
+}
+
+fn comment_prompt(title: &str) -> String {
+    format!("Ticket comment\nTicket: {title}\nLines starting with # are ignored.")
+}
+
 /// Read a ticket title/description body from disk. The first line is the
 /// title; remaining lines become the optional description.
 pub fn read_ticket_edit_file(path: &Path) -> Result<(String, Option<String>)> {
@@ -38,4 +48,17 @@ pub fn parse_ticket_edit(raw: &str) -> Result<(String, Option<String>)> {
     };
 
     Ok((title, description))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn comment_prompt_includes_ticket_title() {
+        let prompt = comment_prompt("Fix the thing");
+
+        assert!(prompt.contains("Ticket: Fix the thing"));
+        assert!(prompt.contains("Lines starting with # are ignored."));
+    }
 }

--- a/crates/ticgit/src/main.rs
+++ b/crates/ticgit/src/main.rs
@@ -6,6 +6,7 @@ mod commands;
 mod editor;
 mod render;
 mod session_state;
+mod timefmt;
 
 fn main() -> anyhow::Result<()> {
     let args = cli::Cli::parse();

--- a/crates/ticgit/src/render.rs
+++ b/crates/ticgit/src/render.rs
@@ -9,6 +9,8 @@ use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
+use crate::timefmt::relative_time;
+
 /// Mapping of email → nick for display purposes.
 pub type NickMap = HashMap<String, String>;
 
@@ -165,7 +167,7 @@ fn tickets_table_with_width(
         out.push(' ');
         out.push_str(&ansi(
             ANSI_DIM,
-            &fit(&relative_date(t.created_at, now), DATE_WIDTH),
+            &fit(&relative_time(t.created_at, now), DATE_WIDTH),
         ));
         out.push_str("  ");
         if t.children.is_empty() {
@@ -210,7 +212,7 @@ pub fn ticket_detail(t: &Ticket, nicks: Option<&NickMap>) -> String {
             &format!(
                 "{} ({})  by {}",
                 friendly_date(t.created_at),
-                relative_date(t.created_at, OffsetDateTime::now_utc()),
+                relative_time(t.created_at, OffsetDateTime::now_utc()),
                 display_name(&t.created_by, nicks)
             ),
         ),
@@ -823,23 +825,6 @@ fn status_color(status: &str) -> &'static str {
         "closed" => ANSI_PURPLE,
         _ => ANSI_DIM,
     }
-}
-
-fn relative_date(then: OffsetDateTime, now: OffsetDateTime) -> String {
-    let seconds = (now - then).whole_seconds().max(0);
-    if seconds < 60 * 60 {
-        return "0d".to_string();
-    }
-    if seconds < 60 * 60 * 24 {
-        return format!("{}h", seconds / (60 * 60));
-    }
-    if seconds < 60 * 60 * 24 * 30 {
-        return format!("{}d", seconds / (60 * 60 * 24));
-    }
-    if seconds < 60 * 60 * 24 * 365 {
-        return format!("{}mo", seconds / (60 * 60 * 24 * 30));
-    }
-    format!("{}y", seconds / (60 * 60 * 24 * 365))
 }
 
 fn friendly_date(when: OffsetDateTime) -> String {

--- a/crates/ticgit/src/render.rs
+++ b/crates/ticgit/src/render.rs
@@ -127,31 +127,44 @@ fn tickets_table_with_width(
     const STATUS_WIDTH: usize = 6;
     const STATE_WIDTH: usize = 11;
     const DATE_WIDTH: usize = 5;
+    const PRIORITY_WIDTH: usize = 4;
     const ASSIGNED_WIDTH: usize = 8;
     const TAGS_WIDTH: usize = 20;
-    const GAPS_AND_MARKER: usize = 15;
     const MIN_TITLE_WIDTH: usize = 12;
 
-    let fixed_width = id_width
-        + STATUS_WIDTH
-        + STATE_WIDTH
-        + DATE_WIDTH
-        + ASSIGNED_WIDTH
-        + TAGS_WIDTH
-        + GAPS_AND_MARKER;
-    let title_width = width.saturating_sub(fixed_width).max(MIN_TITLE_WIDTH);
+    let layout = TableLayout::new(
+        width,
+        id_width,
+        DATE_WIDTH,
+        STATUS_WIDTH,
+        STATE_WIDTH,
+        PRIORITY_WIDTH,
+        ASSIGNED_WIDTH,
+        TAGS_WIDTH,
+        MIN_TITLE_WIDTH,
+    );
 
     let mut out = String::new();
-    let header = format!(
-        "  {} {}  {} {} {} {} {}",
+    let mut header = format!(
+        "  {} {}  {} {} {}",
         fit("TicId", id_width),
         fit("Date", DATE_WIDTH),
-        fit("Title", title_width),
+        fit("Title", layout.title_width),
         fit("Status", STATUS_WIDTH),
-        fit("State", STATE_WIDTH),
-        fit("Assgn", ASSIGNED_WIDTH),
-        fit("Tags", TAGS_WIDTH)
+        fit("State", STATE_WIDTH)
     );
+    if layout.show_priority {
+        header.push(' ');
+        header.push_str(&fit("Pri", PRIORITY_WIDTH));
+    }
+    if layout.show_assigned {
+        header.push(' ');
+        header.push_str(&fit("Assgn", ASSIGNED_WIDTH));
+    }
+    if layout.show_tags {
+        header.push(' ');
+        header.push_str(&fit("Tags", TAGS_WIDTH));
+    }
     out.push_str(&ansi(ANSI_DIM, &header));
     out.push('\n');
     out.push_str(&ansi(ANSI_DIM, &"-".repeat(width)));
@@ -171,10 +184,13 @@ fn tickets_table_with_width(
         ));
         out.push_str("  ");
         if t.children.is_empty() {
-            out.push_str(&ansi(ANSI_BLUE, &fit(&flatten(&t.title), title_width)));
+            out.push_str(&ansi(
+                ANSI_BLUE,
+                &fit(&flatten(&t.title), layout.title_width),
+            ));
         } else {
             let suffix = format!(" [+{}]", t.children.len());
-            let avail = title_width.saturating_sub(suffix.len());
+            let avail = layout.title_width.saturating_sub(suffix.len());
             out.push_str(&ansi(ANSI_BLUE, &fit(&flatten(&t.title), avail)));
             out.push_str(&ansi(ANSI_DIM, &fit(&suffix, suffix.len())));
         }
@@ -188,13 +204,113 @@ fn tickets_table_with_width(
             state_color(t.state.as_str()),
             &fit(t.state.as_str(), STATE_WIDTH),
         ));
-        out.push_str(&fit(&flatten(&assigned), ASSIGNED_WIDTH));
-        out.push(' ');
-        out.push_str(&ansi(ANSI_YELLOW, &fit(&flatten(&tags), TAGS_WIDTH)));
+        if layout.show_priority {
+            out.push(' ');
+            let priority = t
+                .priority
+                .map(|value| value.to_string())
+                .unwrap_or_default();
+            out.push_str(&ansi(ANSI_PURPLE, &fit(&priority, PRIORITY_WIDTH)));
+        }
+        if layout.show_assigned {
+            out.push_str(&fit(&flatten(&assigned), ASSIGNED_WIDTH));
+        }
+        if layout.show_tags {
+            out.push(' ');
+            out.push_str(&ansi(ANSI_YELLOW, &fit(&flatten(&tags), TAGS_WIDTH)));
+        }
         out.push('\n');
     }
 
     out
+}
+
+struct TableLayout {
+    title_width: usize,
+    show_priority: bool,
+    show_assigned: bool,
+    show_tags: bool,
+}
+
+impl TableLayout {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        width: usize,
+        id_width: usize,
+        date_width: usize,
+        status_width: usize,
+        state_width: usize,
+        priority_width: usize,
+        assigned_width: usize,
+        tags_width: usize,
+        min_title_width: usize,
+    ) -> Self {
+        let mut layout = Self {
+            title_width: min_title_width,
+            show_priority: true,
+            show_assigned: true,
+            show_tags: true,
+        };
+
+        while layout.fixed_width_without_title(
+            id_width,
+            date_width,
+            status_width,
+            state_width,
+            priority_width,
+            assigned_width,
+            tags_width,
+        ) + min_title_width
+            > width
+        {
+            if layout.show_tags {
+                layout.show_tags = false;
+            } else if layout.show_assigned {
+                layout.show_assigned = false;
+            } else if layout.show_priority {
+                layout.show_priority = false;
+            } else {
+                break;
+            }
+        }
+
+        let fixed = layout.fixed_width_without_title(
+            id_width,
+            date_width,
+            status_width,
+            state_width,
+            priority_width,
+            assigned_width,
+            tags_width,
+        );
+        layout.title_width = width.saturating_sub(fixed).max(min_title_width);
+        layout
+    }
+
+    fn fixed_width_without_title(
+        &self,
+        id_width: usize,
+        date_width: usize,
+        status_width: usize,
+        state_width: usize,
+        priority_width: usize,
+        assigned_width: usize,
+        tags_width: usize,
+    ) -> usize {
+        let marker_and_required_spacing = 1 + 1 + 1 + 2 + 1 + 1;
+        let mut width =
+            marker_and_required_spacing + id_width + date_width + status_width + state_width;
+        if self.show_priority {
+            width += 1 + priority_width;
+        }
+        if self.show_assigned {
+            width += assigned_width;
+        }
+        if self.show_tags {
+            width += 1 + tags_width;
+        }
+        width
+    }
 }
 
 /// Render a single ticket and its comments, resolving emails to nicks.
@@ -866,6 +982,70 @@ mod tests {
         assert_eq!(refs.get(&open.id), Some(&3));
     }
 
+    #[test]
+    fn tickets_table_shows_priority_when_width_allows() {
+        let mut ticket = ticket(
+            "d7f2d8f6-d6ec-3da1-a180-0a33fb090d59",
+            "priority ticket",
+            TicketState::New,
+        );
+        ticket.priority = Some(2);
+        ticket.assigned = Some("tester@example.com".to_string());
+        ticket.tags.insert("feature".to_string());
+        let refs = open_ticket_ref_lengths(&[ticket.clone()]);
+
+        let table = strip_ansi(&tickets_table_with_width(
+            &[ticket],
+            None,
+            &refs,
+            100,
+            OffsetDateTime::UNIX_EPOCH,
+            None,
+        ));
+
+        assert!(table.contains("Pri"));
+        assert!(table.contains(" 2   "));
+        assert!(table.contains("Assgn"));
+        assert!(table.contains("Tags"));
+    }
+
+    #[test]
+    fn tickets_table_drops_optional_columns_as_width_shrinks() {
+        let mut ticket = ticket(
+            "d7f2d8f6-d6ec-3da1-a180-0a33fb090d59",
+            "priority ticket",
+            TicketState::New,
+        );
+        ticket.priority = Some(2);
+        ticket.assigned = Some("tester@example.com".to_string());
+        ticket.tags.insert("feature".to_string());
+        let refs = open_ticket_ref_lengths(&[ticket.clone()]);
+
+        let medium = strip_ansi(&tickets_table_with_width(
+            &[ticket.clone()],
+            None,
+            &refs,
+            55,
+            OffsetDateTime::UNIX_EPOCH,
+            None,
+        ));
+        assert!(medium.contains("Pri"));
+        assert!(!medium.contains("Assgn"));
+        assert!(!medium.contains("Tags"));
+
+        let narrow = strip_ansi(&tickets_table_with_width(
+            &[ticket],
+            None,
+            &refs,
+            50,
+            OffsetDateTime::UNIX_EPOCH,
+            None,
+        ));
+        assert!(!narrow.contains("Pri"));
+        assert!(!narrow.contains("Assgn"));
+        assert!(!narrow.contains("Tags"));
+    }
+
     fn ticket(id: &str, title: &str, state: TicketState) -> Ticket {
         Ticket {
             id: Uuid::parse_str(id).unwrap(),
@@ -890,5 +1070,22 @@ mod tests {
             created_at: OffsetDateTime::UNIX_EPOCH,
             created_by: "tester@example.com".to_string(),
         }
+    }
+
+    fn strip_ansi(input: &str) -> String {
+        let mut stripped = String::new();
+        let mut chars = input.chars();
+        while let Some(ch) = chars.next() {
+            if ch == '\x1b' {
+                for ch in chars.by_ref() {
+                    if ch == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                stripped.push(ch);
+            }
+        }
+        stripped
     }
 }

--- a/crates/ticgit/src/render.rs
+++ b/crates/ticgit/src/render.rs
@@ -126,8 +126,8 @@ fn tickets_table_with_width(
     let id_width = ref_lengths.values().copied().max().unwrap_or(6).max(6);
     const STATUS_WIDTH: usize = 6;
     const STATE_WIDTH: usize = 11;
-    const DATE_WIDTH: usize = 5;
-    const PRIORITY_WIDTH: usize = 4;
+    const DATE_WIDTH: usize = 3;
+    const PRIORITY_WIDTH: usize = 1;
     const ASSIGNED_WIDTH: usize = 8;
     const TAGS_WIDTH: usize = 20;
     const MIN_TITLE_WIDTH: usize = 12;
@@ -145,9 +145,9 @@ fn tickets_table_with_width(
     );
 
     let mut out = String::new();
-    let mut header = format!("  {} {} ", fit("TicId", id_width), fit("Date", DATE_WIDTH),);
+    let mut header = format!("  {} {} ", fit("TicId", id_width), fit("Dt", DATE_WIDTH),);
     if layout.show_priority {
-        header.push_str(&fit("Pri", PRIORITY_WIDTH));
+        header.push_str(&fit("P", PRIORITY_WIDTH));
         header.push(' ');
     }
     header.push_str(&format!(
@@ -166,8 +166,6 @@ fn tickets_table_with_width(
     }
     out.push_str(&ansi(ANSI_DIM, &header));
     out.push('\n');
-    out.push_str(&ansi(ANSI_DIM, &"-".repeat(width)));
-    out.push('\n');
 
     for t in tickets {
         let marker = if Some(&t.id) == current { "*" } else { " " };
@@ -179,7 +177,7 @@ fn tickets_table_with_width(
         out.push(' ');
         out.push_str(&ansi(
             ANSI_DIM,
-            &fit(&relative_time(t.created_at, now), DATE_WIDTH),
+            &fit(&compact_relative_time(t.created_at, now), DATE_WIDTH),
         ));
         out.push(' ');
         if layout.show_priority {
@@ -190,7 +188,6 @@ fn tickets_table_with_width(
             out.push_str(&ansi(ANSI_PURPLE, &fit(&priority, PRIORITY_WIDTH)));
             out.push(' ');
         }
-        out.push(' ');
         if t.children.is_empty() {
             out.push_str(&ansi(
                 ANSI_BLUE,
@@ -943,6 +940,19 @@ fn status_color(status: &str) -> &'static str {
     }
 }
 
+fn compact_relative_time(then: OffsetDateTime, now: OffsetDateTime) -> String {
+    let label = relative_time(then, now);
+    if label.len() <= 3 {
+        return label;
+    }
+    label
+        .strip_suffix("mo")
+        .unwrap_or(&label)
+        .chars()
+        .take(3)
+        .collect()
+}
+
 fn friendly_date(when: OffsetDateTime) -> String {
     format!(
         "{:04}-{:02}-{:02}",
@@ -1003,9 +1013,9 @@ mod tests {
             None,
         ));
 
-        assert!(table.contains("Pri"));
-        assert!(table.contains(" 2   "));
-        assert!(table.find("Pri").unwrap() < table.find("Title").unwrap());
+        assert!(!table.contains("Pri"));
+        assert!(table.contains("Dt  P  Title"));
+        assert!(table.contains(" 2 priority ticket"));
         assert!(table.contains("Assgn"));
         assert!(table.contains("Tags"));
     }
@@ -1026,11 +1036,13 @@ mod tests {
             &[ticket.clone()],
             None,
             &refs,
-            55,
+            54,
             OffsetDateTime::UNIX_EPOCH,
             None,
         ));
-        assert!(medium.contains("Pri"));
+        assert!(!medium.contains("Pri"));
+        assert!(medium.contains("Dt  P  Title"));
+        assert!(medium.contains(" 2 "));
         assert!(!medium.contains("Assgn"));
         assert!(!medium.contains("Tags"));
 
@@ -1038,13 +1050,43 @@ mod tests {
             &[ticket],
             None,
             &refs,
-            50,
+            46,
             OffsetDateTime::UNIX_EPOCH,
             None,
         ));
-        assert!(!narrow.contains("Pri"));
+        assert!(!narrow.contains(" 2 "));
         assert!(!narrow.contains("Assgn"));
         assert!(!narrow.contains("Tags"));
+    }
+
+    #[test]
+    fn compact_relative_time_fits_table_date_column() {
+        let now = OffsetDateTime::UNIX_EPOCH + time::Duration::days(400);
+
+        assert_eq!(
+            UnicodeWidthStr::width(
+                fit(
+                    &compact_relative_time(now - time::Duration::hours(48), now),
+                    3
+                )
+                .as_str()
+            ),
+            3
+        );
+        assert_eq!(
+            UnicodeWidthStr::width(
+                fit(
+                    &compact_relative_time(now - time::Duration::days(3), now),
+                    3
+                )
+                .as_str()
+            ),
+            3
+        );
+        assert_eq!(
+            compact_relative_time(now - time::Duration::days(360), now),
+            "12"
+        );
     }
 
     fn ticket(id: &str, title: &str, state: TicketState) -> Ticket {

--- a/crates/ticgit/src/render.rs
+++ b/crates/ticgit/src/render.rs
@@ -166,6 +166,8 @@ fn tickets_table_with_width(
     }
     out.push_str(&ansi(ANSI_DIM, &header));
     out.push('\n');
+    out.push_str(&ansi(ANSI_DIM, &"-".repeat(width)));
+    out.push('\n');
 
     for t in tickets {
         let marker = if Some(&t.id) == current { "*" } else { " " };

--- a/crates/ticgit/src/render.rs
+++ b/crates/ticgit/src/render.rs
@@ -145,18 +145,17 @@ fn tickets_table_with_width(
     );
 
     let mut out = String::new();
-    let mut header = format!(
-        "  {} {}  {} {} {}",
-        fit("TicId", id_width),
-        fit("Date", DATE_WIDTH),
+    let mut header = format!("  {} {} ", fit("TicId", id_width), fit("Date", DATE_WIDTH),);
+    if layout.show_priority {
+        header.push_str(&fit("Pri", PRIORITY_WIDTH));
+        header.push(' ');
+    }
+    header.push_str(&format!(
+        " {} {} {}",
         fit("Title", layout.title_width),
         fit("Status", STATUS_WIDTH),
         fit("State", STATE_WIDTH)
-    );
-    if layout.show_priority {
-        header.push(' ');
-        header.push_str(&fit("Pri", PRIORITY_WIDTH));
-    }
+    ));
     if layout.show_assigned {
         header.push(' ');
         header.push_str(&fit("Assgn", ASSIGNED_WIDTH));
@@ -182,7 +181,16 @@ fn tickets_table_with_width(
             ANSI_DIM,
             &fit(&relative_time(t.created_at, now), DATE_WIDTH),
         ));
-        out.push_str("  ");
+        out.push(' ');
+        if layout.show_priority {
+            let priority = t
+                .priority
+                .map(|value| value.to_string())
+                .unwrap_or_default();
+            out.push_str(&ansi(ANSI_PURPLE, &fit(&priority, PRIORITY_WIDTH)));
+            out.push(' ');
+        }
+        out.push(' ');
         if t.children.is_empty() {
             out.push_str(&ansi(
                 ANSI_BLUE,
@@ -204,14 +212,6 @@ fn tickets_table_with_width(
             state_color(t.state.as_str()),
             &fit(t.state.as_str(), STATE_WIDTH),
         ));
-        if layout.show_priority {
-            out.push(' ');
-            let priority = t
-                .priority
-                .map(|value| value.to_string())
-                .unwrap_or_default();
-            out.push_str(&ansi(ANSI_PURPLE, &fit(&priority, PRIORITY_WIDTH)));
-        }
         if layout.show_assigned {
             out.push_str(&fit(&flatten(&assigned), ASSIGNED_WIDTH));
         }
@@ -1005,6 +1005,7 @@ mod tests {
 
         assert!(table.contains("Pri"));
         assert!(table.contains(" 2   "));
+        assert!(table.find("Pri").unwrap() < table.find("Title").unwrap());
         assert!(table.contains("Assgn"));
         assert!(table.contains("Tags"));
     }

--- a/crates/ticgit/src/session_state.rs
+++ b/crates/ticgit/src/session_state.rs
@@ -71,6 +71,8 @@ pub struct SavedView {
     pub subissues: bool,
     #[serde(default, skip_serializing_if = "is_zero")]
     pub limit: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub columns: Vec<String>,
 }
 
 fn is_false(v: &bool) -> bool {

--- a/crates/ticgit/src/timefmt.rs
+++ b/crates/ticgit/src/timefmt.rs
@@ -1,0 +1,36 @@
+use time::OffsetDateTime;
+
+pub fn relative_time(then: OffsetDateTime, now: OffsetDateTime) -> String {
+    let seconds = (now - then).whole_seconds().max(0);
+    if seconds < 60 * 60 {
+        return format!("{}m", seconds / 60);
+    }
+    if seconds < 60 * 60 * 24 {
+        return format!("{}h", seconds / (60 * 60));
+    }
+    if seconds < 60 * 60 * 24 * 30 {
+        return format!("{}d", seconds / (60 * 60 * 24));
+    }
+    if seconds < 60 * 60 * 24 * 365 {
+        return format!("{}mo", seconds / (60 * 60 * 24 * 30));
+    }
+    format!("{}y", seconds / (60 * 60 * 24 * 365))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::Duration;
+
+    #[test]
+    fn relative_time_uses_minutes_hours_days_months_and_years() {
+        let now = OffsetDateTime::UNIX_EPOCH + Duration::days(400);
+
+        assert_eq!(relative_time(now - Duration::seconds(59), now), "0m");
+        assert_eq!(relative_time(now - Duration::minutes(42), now), "42m");
+        assert_eq!(relative_time(now - Duration::hours(23), now), "23h");
+        assert_eq!(relative_time(now - Duration::days(29), now), "29d");
+        assert_eq!(relative_time(now - Duration::days(45), now), "1mo");
+        assert_eq!(relative_time(now - Duration::days(400), now), "1y");
+    }
+}

--- a/crates/ticgit/tests/cli.rs
+++ b/crates/ticgit/tests/cli.rs
@@ -87,6 +87,26 @@ fn editor_script(repo: &TestRepo, contents: &str) -> PathBuf {
 }
 
 #[cfg(unix)]
+fn capturing_editor_script(repo: &TestRepo, captured: &Path, contents: &str) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = repo.state_file.path().join("capturing-editor.sh");
+    fs::write(
+        &path,
+        format!(
+            "#!/bin/sh\ncp \"$1\" \"{}\"\ncat > \"$1\" <<'EOF'\n{contents}\nEOF\n",
+            captured.display()
+        ),
+    )
+    .expect("write capturing editor script");
+
+    let mut permissions = fs::metadata(&path).expect("editor metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).expect("chmod editor script");
+    path
+}
+
+#[cfg(unix)]
 fn executable_script(dir: &Path, name: &str, contents: &str) -> PathBuf {
     use std::os::unix::fs::PermissionsExt;
 
@@ -600,6 +620,36 @@ fn edit_updates_title_and_description() {
     let json: Value = serde_json::from_slice(&output).unwrap();
     assert_eq!(json["title"], "new title");
     assert_eq!(json["description"], "new description\nsecond line");
+}
+
+#[test]
+#[cfg(unix)]
+fn comment_editor_prompt_includes_ticket_title() {
+    let repo = TestRepo::new();
+    let id = create_ticket(&repo, "prompt title");
+    let captured = repo.state_file.path().join("comment-template.md");
+    let editor = capturing_editor_script(&repo, &captured, "edited body\n");
+
+    repo.ti()
+        .env("GIT_EDITOR", &editor)
+        .args(["comment", "-t", &id, "--edit"])
+        .assert()
+        .success();
+
+    let template = fs::read_to_string(captured).unwrap();
+    assert!(template.contains("# Ticket comment"));
+    assert!(template.contains("# Ticket: prompt title"));
+
+    let output = repo
+        .ti()
+        .args(["show", &id, "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["comments"][0]["body"], "edited body");
 }
 
 #[test]

--- a/crates/ticgit/tests/cli.rs
+++ b/crates/ticgit/tests/cli.rs
@@ -133,6 +133,48 @@ fn agent_prints_markdown_guide() {
 }
 
 #[test]
+fn agent_skill_installs_local_shared_skill_and_checks_it() {
+    let repo = TestRepo::new();
+
+    repo.ti()
+        .args(["agent", "skill", "--target", "agents-local"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(".agents/skills/ticgit/SKILL.md"));
+
+    let skill = fs::read_to_string(repo.dir.path().join(".agents/skills/ticgit/SKILL.md"))
+        .expect("skill file");
+    assert!(skill.contains("name: ticgit"));
+    assert!(skill.contains("# TicGit Agent Guide"));
+    assert!(skill.contains("ti list --markdown"));
+
+    repo.ti()
+        .args(["agent", "skill", "--target", "agents-local", "--check"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("installed and current"));
+}
+
+#[test]
+fn agent_skill_installs_agents_md_idempotently() {
+    let repo = TestRepo::new();
+
+    repo.ti()
+        .args(["agent", "skill", "--target", "agents-md"])
+        .assert()
+        .success();
+    repo.ti()
+        .args(["agent", "skill", "--target", "agents-md"])
+        .assert()
+        .success();
+
+    let agents = fs::read_to_string(repo.dir.path().join("AGENTS.md")).expect("AGENTS.md");
+    assert_eq!(agents.matches("<!-- ticgit-agent-start -->").count(), 1);
+    assert!(agents.contains("This project uses TicGit"));
+    assert!(agents.contains("Run `ti agent`"));
+}
+
+#[test]
 fn machine_output_schema_is_published_and_matches_cli_contract() {
     let schema: Value = serde_json::from_str(include_str!(env!("TICGIT_SCHEMA_V1_PATH"))).unwrap();
     assert_eq!(schema["$id"], "https://ticgit.dev/schema/v1.json");
@@ -325,6 +367,36 @@ fn bare_ti_defaults_to_list() {
         .success()
         .stdout(predicate::str::contains("bare ti"))
         .stderr(predicate::str::contains("unknown tag mode").not());
+}
+
+#[test]
+fn list_open_shows_all_open_tickets_without_default_truncation() {
+    let repo = TestRepo::new();
+    for i in 0..25 {
+        create_ticket(&repo, &format!("open ticket {i}"));
+    }
+
+    let default_output = repo
+        .ti()
+        .args(["list", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let default_list: Value = serde_json::from_slice(&default_output).unwrap();
+    assert_eq!(default_list.as_array().unwrap().len(), 20);
+
+    let open_output = repo
+        .ti()
+        .args(["list", "--open", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let open_list: Value = serde_json::from_slice(&open_output).unwrap();
+    assert_eq!(open_list.as_array().unwrap().len(), 25);
 }
 
 #[test]

--- a/crates/ticgit/tests/cli.rs
+++ b/crates/ticgit/tests/cli.rs
@@ -316,6 +316,18 @@ fn help_lists_sync_and_pull_but_not_push() {
 }
 
 #[test]
+fn bare_ti_defaults_to_list() {
+    let repo = TestRepo::new();
+    create_ticket(&repo, "bare ti");
+
+    repo.ti()
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("bare ti"))
+        .stderr(predicate::str::contains("unknown tag mode").not());
+}
+
+#[test]
 fn init_bootstraps_git_meta_defaults() {
     let repo = TestRepo::new();
     git(

--- a/docs/docs/agents.html
+++ b/docs/docs/agents.html
@@ -15,6 +15,7 @@
           <li><a href="getting-started.html">Getting Started</a></li>
           <li><a href="creating-tickets.html">Creating &amp; Browsing</a></li>
           <li><a href="working-on-tickets.html">Working on Tickets</a></li>
+          <li><a href="writeups.html">Writeups</a></li>
           <li><a href="ticket-fields.html">Ticket Fields</a></li>
           <li><a href="views-and-import.html">Views &amp; Import</a></li>
           <li><a href="sync-and-setup.html">Sync &amp; Setup</a></li>

--- a/docs/docs/creating-tickets.html
+++ b/docs/docs/creating-tickets.html
@@ -15,6 +15,7 @@
           <li><a href="getting-started.html">Getting Started</a></li>
           <li class="active"><a href="creating-tickets.html">Creating &amp; Browsing</a></li>
           <li><a href="working-on-tickets.html">Working on Tickets</a></li>
+          <li><a href="writeups.html">Writeups</a></li>
           <li><a href="ticket-fields.html">Ticket Fields</a></li>
           <li><a href="views-and-import.html">Views &amp; Import</a></li>
           <li><a href="sync-and-setup.html">Sync &amp; Setup</a></li>

--- a/docs/docs/getting-started.html
+++ b/docs/docs/getting-started.html
@@ -15,6 +15,7 @@
           <li class="active"><a href="getting-started.html">Getting Started</a></li>
           <li><a href="creating-tickets.html">Creating &amp; Browsing</a></li>
           <li><a href="working-on-tickets.html">Working on Tickets</a></li>
+          <li><a href="writeups.html">Writeups</a></li>
           <li><a href="ticket-fields.html">Ticket Fields</a></li>
           <li><a href="views-and-import.html">Views &amp; Import</a></li>
           <li><a href="sync-and-setup.html">Sync &amp; Setup</a></li>

--- a/docs/docs/sync-and-setup.html
+++ b/docs/docs/sync-and-setup.html
@@ -15,6 +15,7 @@
           <li><a href="getting-started.html">Getting Started</a></li>
           <li><a href="creating-tickets.html">Creating &amp; Browsing</a></li>
           <li><a href="working-on-tickets.html">Working on Tickets</a></li>
+          <li><a href="writeups.html">Writeups</a></li>
           <li><a href="ticket-fields.html">Ticket Fields</a></li>
           <li><a href="views-and-import.html">Views &amp; Import</a></li>
           <li class="active"><a href="sync-and-setup.html">Sync &amp; Setup</a></li>

--- a/docs/docs/ticket-fields.html
+++ b/docs/docs/ticket-fields.html
@@ -15,6 +15,7 @@
           <li><a href="getting-started.html">Getting Started</a></li>
           <li><a href="creating-tickets.html">Creating &amp; Browsing</a></li>
           <li><a href="working-on-tickets.html">Working on Tickets</a></li>
+          <li><a href="writeups.html">Writeups</a></li>
           <li class="active"><a href="ticket-fields.html">Ticket Fields</a></li>
           <li><a href="views-and-import.html">Views &amp; Import</a></li>
           <li><a href="sync-and-setup.html">Sync &amp; Setup</a></li>
@@ -35,7 +36,7 @@
         </header>
 
         <h1>Ticket Fields</h1>
-        <p>Commands: <code>ti tag</code>, <code>ti assign</code>, <code>ti priority</code>, <code>ti points</code>, <code>ti milestone</code>, <code>ti subissue</code>, <code>ti code</code>, <code>ti meta</code>, <code>ti edit</code></p>
+        <p>Commands: <code>ti tag</code>, <code>ti assign</code>, <code>ti priority</code>, <code>ti points</code>, <code>ti milestone</code>, <code>ti subissue</code>, <code>ti spec</code>, <code>ti code</code>, <code>ti meta</code>, <code>ti edit</code></p>
         <p>Every ticket has a set of built-in fields. These commands let you set them without opening an editor.</p>
 
         <h2>Tags</h2>
@@ -178,6 +179,7 @@
 
         <h2>Spec</h2>
         <p>The spec field holds implementation specifications -- the "how", separate from the description's "what/why". It's a top-level ticket field like title and description.</p>
+        <p>Use a spec when the ticket title and description identify the problem, but the implementation path needs to be agreed on before coding. Specs are especially useful for multi-step changes, agent workflows, and review handoff because they travel with the ticket and show up in JSON, Markdown, and filtered output.</p>
 
         <h3>Viewing the spec</h3>
         <p>When a spec is set, <code>ti show</code> displays its first line in the ticket header:</p>
@@ -240,6 +242,9 @@
           <div class="term-body">
             <div class="line"><span class="prompt">$</span> ti spec</div>
             <div class="line dim">Opens $EDITOR with the current spec for editing.</div>
+            <div class="line">&nbsp;</div>
+            <div class="line"><span class="prompt">$</span> ti spec --ticket a3f</div>
+            <div class="line dim">Edit the spec for a specific ticket.</div>
           </div>
         </div>
 

--- a/docs/docs/views-and-import.html
+++ b/docs/docs/views-and-import.html
@@ -15,6 +15,7 @@
           <li><a href="getting-started.html">Getting Started</a></li>
           <li><a href="creating-tickets.html">Creating &amp; Browsing</a></li>
           <li><a href="working-on-tickets.html">Working on Tickets</a></li>
+          <li><a href="writeups.html">Writeups</a></li>
           <li><a href="ticket-fields.html">Ticket Fields</a></li>
           <li class="active"><a href="views-and-import.html">Views &amp; Import</a></li>
           <li><a href="sync-and-setup.html">Sync &amp; Setup</a></li>

--- a/docs/docs/working-on-tickets.html
+++ b/docs/docs/working-on-tickets.html
@@ -15,6 +15,7 @@
           <li><a href="getting-started.html">Getting Started</a></li>
           <li><a href="creating-tickets.html">Creating &amp; Browsing</a></li>
           <li class="active"><a href="working-on-tickets.html">Working on Tickets</a></li>
+          <li><a href="writeups.html">Writeups</a></li>
           <li><a href="ticket-fields.html">Ticket Fields</a></li>
           <li><a href="views-and-import.html">Views &amp; Import</a></li>
           <li><a href="sync-and-setup.html">Sync &amp; Setup</a></li>

--- a/docs/docs/writeups.html
+++ b/docs/docs/writeups.html
@@ -1,0 +1,178 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>writeups - ticgit docs</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <button class="menu-toggle" onclick="document.querySelector('.sidebar').classList.toggle('open')">MENU</button>
+    <div class="layout">
+      <nav class="sidebar">
+        <a class="sidebar-title" href="../index.html">TICGIT</a>
+        <ul>
+          <li><a href="getting-started.html">Getting Started</a></li>
+          <li><a href="creating-tickets.html">Creating &amp; Browsing</a></li>
+          <li><a href="working-on-tickets.html">Working on Tickets</a></li>
+          <li class="active"><a href="writeups.html">Writeups</a></li>
+          <li><a href="ticket-fields.html">Ticket Fields</a></li>
+          <li><a href="views-and-import.html">Views &amp; Import</a></li>
+          <li><a href="sync-and-setup.html">Sync &amp; Setup</a></li>
+          <li><a href="agents.html">Agent Integration</a></li>
+        </ul>
+        <div class="sidebar-footer">
+          <a href="https://github.com/schacon/ticgit">github</a>
+          <a href="https://github.com/schacon/ticgit/releases">changelog</a>
+        </div>
+      </nav>
+
+      <main class="content">
+        <header class="doc-header">
+          <div class="topline">
+            <span>TICGIT DOCS</span>
+            <span>WRITEUPS</span>
+          </div>
+        </header>
+
+        <h1>Writeups</h1>
+        <p>Commands: <code>ti writeup new</code>, <code>ti writeup list</code>, <code>ti writeup show</code>, <code>ti writeup edit</code>, <code>ti writeup promote</code>, <code>ti writeup link</code>, <code>ti writeup unlink</code>, <code>ti writeup close</code></p>
+        <p>Writeups are versioned notes that live next to tickets. Use them for investigation notes, design sketches, release notes, longer implementation plans, or anything that should be preserved without becoming an actionable ticket immediately.</p>
+
+        <h2>When to use a writeup</h2>
+        <p>Use a ticket when the next action is clear and tracked through the lifecycle. Use a writeup when the work is exploratory, narrative, or expected to evolve over several edits before it becomes ticket-sized.</p>
+
+        <table>
+          <thead>
+            <tr><th>Use a ticket for</th><th>Use a writeup for</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Known bugs and tasks</td><td>Research notes and findings</td></tr>
+            <tr><td>Work that needs assignment or priority</td><td>Design alternatives and tradeoffs</td></tr>
+            <tr><td>Items that should move through state</td><td>Long-form implementation notes</td></tr>
+            <tr><td>Small, reviewable units of work</td><td>Drafts that may later become tickets</td></tr>
+          </tbody>
+        </table>
+
+        <h2>Create</h2>
+        <p>Create a writeup with a title and optional body. If the title or body is omitted, TicGit opens your editor.</p>
+
+        <div class="terminal dark">
+          <div class="term-header"><span>NEW WRITEUP</span></div>
+          <div class="term-body">
+            <div class="line"><span class="prompt">$</span> ti writeup new --title "Auth migration plan" --body "Move sessions to signed JWTs."</div>
+            <div class="line dim">Created writeup b4d1a2 (Auth migration plan)</div>
+            <div class="line dim">Full id: b4d1a2f0-2d3b-4c8b-9b0d-...</div>
+            <div class="line">&nbsp;</div>
+            <div class="line"><span class="prompt">$</span> ti writeup new --title "Parser cleanup" --file notes.md --tags design,parser</div>
+          </div>
+        </div>
+
+        <h2>List and read</h2>
+        <p>By default, <code>ti writeup list</code> shows open writeups. Pass <code>--all</code> to include closed writeups.</p>
+
+        <div class="terminal dark">
+          <div class="term-header"><span>LIST WRITEUPS</span></div>
+          <div class="term-body">
+            <div class="line"><span class="prompt">$</span> ti writeup list</div>
+            <div class="line dim">b4d1a2 open   1      v1 Auth migration plan [design,auth]</div>
+            <div class="line dim">9c17ee open   2      v3 Parser cleanup [parser]</div>
+            <div class="line">&nbsp;</div>
+            <div class="line"><span class="prompt">$</span> ti writeup list --all</div>
+          </div>
+        </div>
+
+        <div class="terminal">
+          <div class="term-header"><span>SHOW WRITEUP</span></div>
+          <div class="term-body">
+            <div class="line"><span class="prompt">$</span> ti writeup show b4d1a2</div>
+            <div class="line dim">Shows the latest version.</div>
+            <div class="line">&nbsp;</div>
+            <div class="line"><span class="prompt">$</span> ti writeup show b4d1a2 --all</div>
+            <div class="line dim">Shows every saved version.</div>
+          </div>
+        </div>
+
+        <h2>Edit versions</h2>
+        <p>Editing a writeup appends a new version instead of replacing the old one. That makes writeups useful for evolving notes where previous context still matters.</p>
+
+        <div class="terminal dark">
+          <div class="term-header"><span>APPEND VERSION</span></div>
+          <div class="term-body">
+            <div class="line"><span class="prompt">$</span> ti writeup edit b4d1a2</div>
+            <div class="line dim">Opens $EDITOR with the latest version prefilled.</div>
+            <div class="line">&nbsp;</div>
+            <div class="line"><span class="prompt">$</span> ti writeup edit b4d1a2 --body "Updated plan after review."</div>
+            <div class="line dim">Appended version 2 to writeup b4d1a2.</div>
+            <div class="line">&nbsp;</div>
+            <div class="line"><span class="prompt">$</span> ti writeup edit b4d1a2 --file revised-plan.md</div>
+          </div>
+        </div>
+
+        <h2>Link to tickets</h2>
+        <p>A writeup can be linked to one or more tickets. Use this when a design note, investigation, or implementation record explains why a ticket exists or how it was handled.</p>
+
+        <div class="terminal dark">
+          <div class="term-header"><span>LINK WRITEUP TO TICKET</span></div>
+          <div class="term-body">
+            <div class="line"><span class="prompt">$</span> ti writeup link b4d1a2 a3f29c</div>
+            <div class="line dim">Linked writeup b4d1a2 to ticket a3f29c.</div>
+            <div class="line">&nbsp;</div>
+            <div class="line"><span class="prompt">$</span> ti writeup unlink b4d1a2 a3f29c</div>
+          </div>
+        </div>
+
+        <p>Linked writeups show up in the TUI details pane and keep the long-form context close to the ticket without overloading ticket comments.</p>
+
+        <h2>Promote into a ticket</h2>
+        <p>When a writeup turns into actionable work, promote it. TicGit creates a new ticket from the writeup title and latest body.</p>
+
+        <div class="terminal dark">
+          <div class="term-header"><span>PROMOTE</span></div>
+          <div class="term-body">
+            <div class="line"><span class="prompt">$</span> ti writeup promote b4d1a2</div>
+            <div class="line dim">Promoted writeup b4d1a2 to ticket e70ac1 (Auth migration plan)</div>
+            <div class="line dim">Full ticket id: e70ac13a-...</div>
+          </div>
+        </div>
+
+        <h2>Close or archive</h2>
+        <p>Close a writeup when it is no longer active. <code>archive</code> is an alias for <code>close</code>.</p>
+
+        <div class="terminal">
+          <div class="term-header"><span>CLOSE</span></div>
+          <div class="term-body">
+            <div class="line"><span class="prompt">$</span> ti writeup close b4d1a2</div>
+            <div class="line dim">Closed writeup b4d1a2.</div>
+            <div class="line">&nbsp;</div>
+            <div class="line"><span class="prompt">$</span> ti writeup archive b4d1a2</div>
+          </div>
+        </div>
+
+        <h2>Workflow</h2>
+        <p>A common workflow is to start with notes, revise them as the idea becomes concrete, then either link the writeup to existing work or promote it into a ticket.</p>
+
+        <div class="terminal dark">
+          <div class="term-header"><span>WRITEUP TO TICKET</span></div>
+          <div class="term-body">
+            <div class="line"><span class="prompt">$</span> ti writeup new --title "Search ranking notes" --tags research</div>
+            <div class="line dim">Capture early findings in $EDITOR.</div>
+            <div class="line">&nbsp;</div>
+            <div class="line"><span class="prompt">$</span> ti writeup edit 9c17ee --file ranking-v2.md</div>
+            <div class="line"><span class="prompt">$</span> ti writeup show 9c17ee --all</div>
+            <div class="line">&nbsp;</div>
+            <div class="line"><span class="prompt">$</span> ti writeup promote 9c17ee</div>
+            <div class="line"><span class="prompt">$</span> ti checkout e70ac1</div>
+            <div class="line"><span class="prompt">$</span> ti spec --file implementation-plan.md</div>
+            <div class="line"><span class="prompt">$</span> ti state assigned</div>
+          </div>
+        </div>
+
+        <footer class="doc-footer">
+          <span>$ cargo install ticgit</span>
+          <span><a href="https://github.com/schacon/ticgit">github</a> &middot; <a href="https://github.com/schacon/ticgit/releases">changelog</a></span>
+        </footer>
+      </main>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add configurable TUI issue-list columns and persist them in saved views
- add a TUI dashboard tab and expand `ti stats` with recently opened tickets
- improve comment editor context and add docs for specs/writeups

## Verification
- `cargo test -p ticgit`
- `cargo run -p ticgit -- stats`