### PR TITLE
Refine TUI subissue controls

### DIFF
--- a/crates/ticgit/src/commands/tui.rs
+++ b/crates/ticgit/src/commands/tui.rs
@@ -193,6 +193,7 @@ struct App {
     assigned_filter: Option<String>,
     only_tagged: bool,
     hide_subissues: bool,
+    show_subissues_preference: bool,
     sort_order: Option<SortOrder>,
     sort_closed_desc: bool,
     closed_at: HashMap<uuid::Uuid, OffsetDateTime>,
@@ -373,6 +374,7 @@ impl App {
             .detail_width_percent
             .unwrap_or(DETAIL_WIDTH_PERCENT_DEFAULT)
             .clamp(DETAIL_WIDTH_PERCENT_MIN, DETAIL_WIDTH_PERCENT_MAX);
+        let show_subissues_preference = project_settings.show_subissues.unwrap_or(false);
         let mut app = Self {
             store,
             all_tickets: Vec::new(),
@@ -396,7 +398,8 @@ impl App {
             base_state: None,
             assigned_filter: None,
             only_tagged: false,
-            hide_subissues: false,
+            hide_subissues: !show_subissues_preference,
+            show_subissues_preference,
             sort_order: None,
             sort_closed_desc: false,
             closed_at: HashMap::new(),
@@ -1083,6 +1086,10 @@ impl App {
                             desc: "outline",
                         },
                         MenuHint {
+                            key: "U",
+                            desc: "subissues",
+                        },
+                        MenuHint {
                             key: "s",
                             desc: "state",
                         },
@@ -1134,6 +1141,10 @@ impl App {
                             desc: "list",
                         },
                         MenuHint {
+                            key: "U",
+                            desc: "subissues",
+                        },
+                        MenuHint {
                             key: "b",
                             desc: "board",
                         },
@@ -1175,6 +1186,10 @@ impl App {
                         MenuHint {
                             key: "u",
                             desc: "outline",
+                        },
+                        MenuHint {
+                            key: "U",
+                            desc: "subissues",
                         },
                         MenuHint {
                             key: "n",
@@ -1280,6 +1295,10 @@ impl App {
                             desc: "outline",
                         },
                         MenuHint {
+                            key: "U",
+                            desc: "subissues",
+                        },
+                        MenuHint {
                             key: "n",
                             desc: "new",
                         },
@@ -1341,17 +1360,28 @@ impl App {
         let compact = self.detail.is_some();
         let columns = issue_columns_for_width(&self.issue_columns, row_width);
         let widths = issue_column_widths(&columns, row_width);
+        let ticket_by_id = self
+            .all_tickets
+            .iter()
+            .map(|ticket| (ticket.id, ticket))
+            .collect::<HashMap<_, _>>();
 
         let items: Vec<ListItem<'_>> = self
             .visible
             .iter()
             .map(|&idx| {
                 let ticket = &self.tickets[idx];
+                let title_prefix = if self.hide_subissues {
+                    String::new()
+                } else {
+                    subissue_graph_prefix(ticket, &ticket_by_id)
+                };
                 ListItem::new(ticket_table_line(
                     ticket,
                     &columns,
                     &widths,
                     row_width,
+                    &title_prefix,
                     compact,
                     self.store.email(),
                     self.closed_at.get(&ticket.id).copied(),
@@ -2769,7 +2799,10 @@ impl App {
 
                 help_section(&mut lines, "Views");
                 lines.push(help_columns(("b", "list view"), Some(("d", "stats view"))));
-                lines.push(help_columns(("u", "outline view"), None));
+                lines.push(help_columns(
+                    ("u", "outline view"),
+                    Some(("U", "subissues")),
+                ));
             }
             Mode::Normal if self.view == ViewMode::Outline && self.detail.is_none() => {
                 help_section(&mut lines, "Outline");
@@ -2794,7 +2827,7 @@ impl App {
 
                 help_section(&mut lines, "Views");
                 lines.push(help_columns(("u", "list view"), Some(("b", "board view"))));
-                lines.push(help_columns(("d", "stats view"), None));
+                lines.push(help_columns(("d", "stats view"), Some(("U", "subissues"))));
             }
             Mode::Normal => {
                 help_section(&mut lines, "Navigation");
@@ -2833,7 +2866,10 @@ impl App {
 
                 help_section(&mut lines, "Views");
                 lines.push(help_columns(("b", "board view"), Some(("d", "stats view"))));
-                lines.push(help_columns(("u", "outline view"), None));
+                lines.push(help_columns(
+                    ("u", "outline view"),
+                    Some(("U", "subissues")),
+                ));
             }
         }
 
@@ -3021,6 +3057,12 @@ impl App {
                     self.handle_outline_key()?;
                 } else if self.active_tab == TuiTab::Writeups && self.writeup_detail.is_some() {
                     self.begin_unlink_issue_select();
+                }
+                false
+            }
+            KeyCode::Char('U') => {
+                if self.active_tab == TuiTab::Issues {
+                    self.toggle_subissue_visibility()?;
                 }
                 false
             }
@@ -3773,7 +3815,7 @@ impl App {
         self.base_state = None;
         self.assigned_filter = None;
         self.only_tagged = false;
-        self.hide_subissues = false;
+        self.hide_subissues = !self.show_subissues_preference;
         self.sort_order = None;
         self.sort_closed_desc = false;
         self.issue_columns = default_issue_columns();
@@ -3794,7 +3836,7 @@ impl App {
             || self.base_state.is_some()
             || self.assigned_filter.is_some()
             || self.only_tagged
-            || self.hide_subissues
+            || self.hide_subissues != !self.show_subissues_preference
             || self.sort_order.is_some()
             || !self.filter.is_empty()
             || !self.tag_filter.is_empty()
@@ -4627,9 +4669,6 @@ impl App {
         if self.only_tagged {
             parts.push("tagged only".to_string());
         }
-        if self.hide_subissues {
-            parts.push("no subissues".to_string());
-        }
         if !self.filter.is_empty() {
             parts.push(format!("\"{}\"", self.filter));
         }
@@ -5120,6 +5159,7 @@ impl App {
         let mut state = State::load().unwrap_or_default();
         let mut settings = state.project_settings_for(&git_dir);
         settings.detail_width_percent = Some(self.detail_width_percent);
+        settings.show_subissues = Some(self.show_subissues_preference);
         state.set_project_settings(&git_dir, settings);
         state.save()
     }
@@ -5231,6 +5271,20 @@ impl App {
         self.detail = None;
         self.writeup_detail = None;
         self.comments_mode = false;
+    }
+
+    fn toggle_subissue_visibility(&mut self) -> Result<()> {
+        let selected_id = self.selected_ticket().map(|ticket| ticket.id);
+        self.show_subissues_preference = self.hide_subissues;
+        self.hide_subissues = !self.show_subissues_preference;
+        self.save_project_settings()?;
+        self.reload(selected_id)?;
+        self.status = Some(if self.hide_subissues {
+            "Hiding subissues.".to_string()
+        } else {
+            "Showing subissues.".to_string()
+        });
+        Ok(())
     }
 
     fn open_board_for_detail_ticket(&mut self) {
@@ -5869,6 +5923,41 @@ fn outline_ticket_line(
     Line::from(spans)
 }
 
+fn subissue_graph_prefix(ticket: &Ticket, ticket_by_id: &HashMap<uuid::Uuid, &Ticket>) -> String {
+    let depth = subissue_depth(ticket, ticket_by_id).min(5);
+    if depth == 0 {
+        return if ticket.children.is_empty() {
+            String::new()
+        } else {
+            "+ ".to_string()
+        };
+    }
+
+    let marker = if ticket.children.is_empty() {
+        "`- "
+    } else {
+        "+- "
+    };
+    format!("{}{}", "  ".repeat(depth.saturating_sub(1)), marker)
+}
+
+fn subissue_depth(ticket: &Ticket, ticket_by_id: &HashMap<uuid::Uuid, &Ticket>) -> usize {
+    let mut depth = 0;
+    let mut current = ticket;
+    let mut seen = BTreeSet::new();
+    while let Some(parent) = current.parent {
+        if !seen.insert(parent) {
+            break;
+        }
+        let Some(parent_ticket) = ticket_by_id.get(&parent).copied() else {
+            break;
+        };
+        depth += 1;
+        current = parent_ticket;
+    }
+    depth
+}
+
 fn build_outline_rows(
     tickets: &[Ticket],
     visible: &[usize],
@@ -6085,6 +6174,7 @@ fn ticket_table_line(
     columns: &[IssueColumn],
     widths: &[usize],
     width: usize,
+    title_prefix: &str,
     _compact: bool,
     current_user: &str,
     closed_at: Option<OffsetDateTime>,
@@ -6103,6 +6193,9 @@ fn ticket_table_line(
                 ticket.assigned.as_deref() == Some(current_user),
             ),
             IssueColumn::Tags => push_issue_tags_column(&mut spans, &ticket.tags, *column_width),
+            IssueColumn::Title => {
+                push_issue_title_column(&mut spans, ticket, *column_width, title_prefix);
+            }
             _ => {
                 let (value, style) = issue_column_value(ticket, *column, closed_at, current_user);
                 spans.push(Span::styled(fit_display(&value, *column_width), style));
@@ -6148,6 +6241,28 @@ fn push_issue_id_column(
     if padding_width > 0 {
         spans.push(Span::raw(" ".repeat(padding_width)));
     }
+}
+
+fn push_issue_title_column(
+    spans: &mut Vec<Span<'static>>,
+    ticket: &Ticket,
+    width: usize,
+    title_prefix: &str,
+) {
+    if title_prefix.is_empty() {
+        let (value, style) = issue_column_value(ticket, IssueColumn::Title, None, "");
+        spans.push(Span::styled(fit_display(&value, width), style));
+        return;
+    }
+
+    let prefix = truncate_display(title_prefix, width);
+    let prefix_width = UnicodeWidthStr::width(prefix.as_str());
+    spans.push(Span::styled(prefix, Style::default().fg(Color::DarkGray)));
+    let title = flatten_display(&ticket.title);
+    spans.push(Span::styled(
+        fit_display(&title, width.saturating_sub(prefix_width)),
+        Style::default().fg(Color::Reset),
+    ));
 }
 
 fn push_issue_tags_column(spans: &mut Vec<Span<'static>>, tags: &BTreeSet<String>, width: usize) {
@@ -7025,7 +7140,6 @@ fn builtin_views(current_user: &str) -> Vec<ViewEntry> {
             name: "Default".to_string(),
             view: SavedView {
                 status: Some("open".to_string()),
-                subissues: true,
                 tag_match_all: true,
                 columns: default_issue_column_names(),
                 ..Default::default()
@@ -7037,7 +7151,6 @@ fn builtin_views(current_user: &str) -> Vec<ViewEntry> {
             view: SavedView {
                 status: Some("open".to_string()),
                 assigned: Some(current_user.to_string()),
-                subissues: true,
                 tag_match_all: true,
                 columns: default_issue_column_names(),
                 ..Default::default()
@@ -7049,7 +7162,6 @@ fn builtin_views(current_user: &str) -> Vec<ViewEntry> {
             view: SavedView {
                 status: Some("closed".to_string()),
                 order: Some("closed.desc".to_string()),
-                subissues: true,
                 tag_match_all: true,
                 columns: vec![
                     "id".to_string(),
@@ -7730,6 +7842,16 @@ mod tests {
     }
 
     #[test]
+    fn default_open_views_hide_subissues() {
+        let views = builtin_views("me@example.com");
+
+        for name in ["Default", "Mine", "Recently Closed"] {
+            let view = views.iter().find(|view| view.name == name).unwrap();
+            assert!(!view.view.subissues, "{name} should hide subissues");
+        }
+    }
+
+    #[test]
     fn id_column_reserves_space_for_claimed_marker() {
         assert_eq!(IssueColumn::Id.fixed_width(), Some(4));
     }
@@ -7794,6 +7916,26 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![(root, 0, true), (sibling, 0, false)]
         );
+    }
+
+    #[test]
+    fn subissue_graph_prefix_marks_parents_and_children() {
+        let root = uuid::Uuid::from_u128(1);
+        let child = uuid::Uuid::from_u128(2);
+        let grandchild = uuid::Uuid::from_u128(3);
+        let tickets = vec![
+            test_ticket(root, None, &[child]),
+            test_ticket(child, Some(root), &[grandchild]),
+            test_ticket(grandchild, Some(child), &[]),
+        ];
+        let ticket_by_id = tickets
+            .iter()
+            .map(|ticket| (ticket.id, ticket))
+            .collect::<HashMap<_, _>>();
+
+        assert_eq!(subissue_graph_prefix(&tickets[0], &ticket_by_id), "+ ");
+        assert_eq!(subissue_graph_prefix(&tickets[1], &ticket_by_id), "+- ");
+        assert_eq!(subissue_graph_prefix(&tickets[2], &ticket_by_id), "  `- ");
     }
 
     fn test_ticket(id: uuid::Uuid, parent: Option<uuid::Uuid>, children: &[uuid::Uuid]) -> Ticket {

--- a/crates/ticgit/src/commands/tui.rs
+++ b/crates/ticgit/src/commands/tui.rs
@@ -460,14 +460,14 @@ impl App {
         self.apply_filter();
 
         if let Some(id) = preferred_id {
-            if let Some(visible_pos) = self
-                .visible
+            let list_indices = self.list_ticket_indices();
+            if let Some(list_pos) = list_indices
                 .iter()
                 .position(|idx| self.tickets[*idx].id == id)
             {
-                self.list_state.select(Some(visible_pos));
+                self.list_state.select(Some(list_pos));
                 if self.detail.is_some() {
-                    self.detail = self.visible.get(visible_pos).copied();
+                    self.detail = list_indices.get(list_pos).copied();
                 }
             } else if self.detail.is_some() {
                 self.detail = None;
@@ -1367,7 +1367,7 @@ impl App {
             .collect::<HashMap<_, _>>();
 
         let items: Vec<ListItem<'_>> = self
-            .visible
+            .list_ticket_indices()
             .iter()
             .map(|&idx| {
                 let ticket = &self.tickets[idx];
@@ -4938,14 +4938,11 @@ impl App {
 
         self.detail = self.detail.filter(|idx| self.visible.contains(idx));
         self.sync_board_selection();
-        if self.visible.is_empty() {
+        let list_len = self.list_ticket_indices().len();
+        if list_len == 0 {
             self.list_state.select(None);
         } else {
-            let selected = self
-                .list_state
-                .selected()
-                .unwrap_or(0)
-                .min(self.visible.len() - 1);
+            let selected = self.list_state.selected().unwrap_or(0).min(list_len - 1);
             self.list_state.select(Some(selected));
         }
         self.sync_outline_selection();
@@ -4992,11 +4989,12 @@ impl App {
         if self.active_tab == TuiTab::Dashboard {
             return;
         }
-        if self.visible.is_empty() {
+        let list_len = self.list_ticket_indices().len();
+        if list_len == 0 {
             return;
         }
         let selected = self.list_state.selected().unwrap_or(0);
-        let next = (selected + 1) % self.visible.len();
+        let next = (selected + 1) % list_len;
         self.list_state.select(Some(next));
         self.sync_open_detail();
     }
@@ -5009,15 +5007,20 @@ impl App {
         if self.active_tab == TuiTab::Dashboard {
             return;
         }
-        if self.visible.is_empty() {
+        let list_len = self.list_ticket_indices().len();
+        if list_len == 0 {
             return;
         }
         let selected = self.list_state.selected().unwrap_or(0);
         let previous = selected
             .checked_sub(1)
-            .unwrap_or_else(|| self.visible.len().saturating_sub(1));
+            .unwrap_or_else(|| list_len.saturating_sub(1));
         self.list_state.select(Some(previous));
         self.sync_open_detail();
+    }
+
+    fn list_ticket_indices(&self) -> Vec<usize> {
+        ordered_list_indices(&self.tickets, &self.visible, !self.hide_subissues)
     }
 
     fn next_writeup(&mut self) {
@@ -5321,9 +5324,7 @@ impl App {
         }
         if let Some(idx) = self.selected_ticket_index() {
             self.detail = Some(idx);
-            if let Some(visible_pos) = self.visible.iter().position(|visible| *visible == idx) {
-                self.list_state.select(Some(visible_pos));
-            }
+            self.select_list_ticket_by_index(idx);
             if self.view == ViewMode::Outline {
                 self.select_outline_ticket_by_id(self.tickets[idx].id);
             }
@@ -5346,13 +5347,13 @@ impl App {
     }
 
     fn open_ticket_by_id(&mut self, id: uuid::Uuid) {
-        if let Some(visible_pos) = self
-            .visible
+        let list_indices = self.list_ticket_indices();
+        if let Some(list_pos) = list_indices
             .iter()
             .position(|idx| self.tickets[*idx].id == id)
         {
-            self.list_state.select(Some(visible_pos));
-            self.detail = self.visible.get(visible_pos).copied();
+            self.list_state.select(Some(list_pos));
+            self.detail = list_indices.get(list_pos).copied();
             self.comments_mode = false;
             if self.view == ViewMode::Outline {
                 self.select_outline_ticket_by_id(id);
@@ -5427,9 +5428,7 @@ impl App {
 
     fn sync_board_to_list_selection(&mut self) {
         if let Some(idx) = self.selected_ticket_index() {
-            if let Some(visible_pos) = self.visible.iter().position(|visible| *visible == idx) {
-                self.list_state.select(Some(visible_pos));
-            }
+            self.select_list_ticket_by_index(idx);
         }
     }
 
@@ -5449,13 +5448,17 @@ impl App {
 
     fn sync_outline_to_list_selection(&mut self) {
         if let Some(row) = self.selected_outline_row() {
-            if let Some(visible_pos) = self
-                .visible
-                .iter()
-                .position(|visible| *visible == row.ticket_idx)
-            {
-                self.list_state.select(Some(visible_pos));
-            }
+            self.select_list_ticket_by_index(row.ticket_idx);
+        }
+    }
+
+    fn select_list_ticket_by_index(&mut self, idx: usize) {
+        if let Some(list_pos) = self
+            .list_ticket_indices()
+            .iter()
+            .position(|candidate| *candidate == idx)
+        {
+            self.list_state.select(Some(list_pos));
         }
     }
 
@@ -5559,8 +5562,7 @@ impl App {
         }
         self.list_state
             .selected()
-            .and_then(|selected| self.visible.get(selected))
-            .copied()
+            .and_then(|selected| self.list_ticket_indices().get(selected).copied())
     }
 
     fn selected_writeup(&self) -> Option<&Writeup> {
@@ -5929,16 +5931,16 @@ fn subissue_graph_prefix(ticket: &Ticket, ticket_by_id: &HashMap<uuid::Uuid, &Ti
         return if ticket.children.is_empty() {
             String::new()
         } else {
-            "+ ".to_string()
+            "╰┄ ".to_string()
         };
     }
 
     let marker = if ticket.children.is_empty() {
-        "`- "
+        "├╮ "
     } else {
-        "+- "
+        "╰┄ "
     };
-    format!("{}{}", "  ".repeat(depth.saturating_sub(1)), marker)
+    format!("{}{}", "┊".repeat(depth), marker)
 }
 
 fn subissue_depth(ticket: &Ticket, ticket_by_id: &HashMap<uuid::Uuid, &Ticket>) -> usize {
@@ -5956,6 +5958,16 @@ fn subissue_depth(ticket: &Ticket, ticket_by_id: &HashMap<uuid::Uuid, &Ticket>) 
         current = parent_ticket;
     }
     depth
+}
+
+fn ordered_list_indices(tickets: &[Ticket], visible: &[usize], show_subissues: bool) -> Vec<usize> {
+    if !show_subissues {
+        return visible.to_vec();
+    }
+    build_outline_rows(tickets, visible, &BTreeSet::new())
+        .into_iter()
+        .map(|row| row.ticket_idx)
+        .collect()
 }
 
 fn build_outline_rows(
@@ -7933,9 +7945,30 @@ mod tests {
             .map(|ticket| (ticket.id, ticket))
             .collect::<HashMap<_, _>>();
 
-        assert_eq!(subissue_graph_prefix(&tickets[0], &ticket_by_id), "+ ");
-        assert_eq!(subissue_graph_prefix(&tickets[1], &ticket_by_id), "+- ");
-        assert_eq!(subissue_graph_prefix(&tickets[2], &ticket_by_id), "  `- ");
+        assert_eq!(subissue_graph_prefix(&tickets[0], &ticket_by_id), "╰┄ ");
+        assert_eq!(subissue_graph_prefix(&tickets[1], &ticket_by_id), "┊╰┄ ");
+        assert_eq!(subissue_graph_prefix(&tickets[2], &ticket_by_id), "┊┊├╮ ");
+    }
+
+    #[test]
+    fn list_order_places_visible_children_after_parent() {
+        let root = uuid::Uuid::from_u128(1);
+        let child = uuid::Uuid::from_u128(2);
+        let sibling = uuid::Uuid::from_u128(3);
+        let tickets = vec![
+            test_ticket(root, None, &[child]),
+            test_ticket(child, Some(root), &[]),
+            test_ticket(sibling, None, &[]),
+        ];
+
+        assert_eq!(
+            ordered_list_indices(&tickets, &[1, 0, 2], false),
+            vec![1, 0, 2]
+        );
+        assert_eq!(
+            ordered_list_indices(&tickets, &[1, 0, 2], true),
+            vec![0, 1, 2]
+        );
     }
 
     fn test_ticket(id: uuid::Uuid, parent: Option<uuid::Uuid>, children: &[uuid::Uuid]) -> Ticket {

--- a/crates/ticgit/src/commands/tui.rs
+++ b/crates/ticgit/src/commands/tui.rs
@@ -5928,11 +5928,7 @@ fn outline_ticket_line(
 fn subissue_graph_prefix(ticket: &Ticket, ticket_by_id: &HashMap<uuid::Uuid, &Ticket>) -> String {
     let depth = subissue_depth(ticket, ticket_by_id).min(5);
     if depth == 0 {
-        return if ticket.children.is_empty() {
-            String::new()
-        } else {
-            "╰┄ ".to_string()
-        };
+        return String::new();
     }
 
     let marker = if ticket.children.is_empty() {
@@ -7945,7 +7941,7 @@ mod tests {
             .map(|ticket| (ticket.id, ticket))
             .collect::<HashMap<_, _>>();
 
-        assert_eq!(subissue_graph_prefix(&tickets[0], &ticket_by_id), "╰┄ ");
+        assert_eq!(subissue_graph_prefix(&tickets[0], &ticket_by_id), "");
         assert_eq!(subissue_graph_prefix(&tickets[1], &ticket_by_id), "┊╰┄ ");
         assert_eq!(subissue_graph_prefix(&tickets[2], &ticket_by_id), "┊┊├╮ ");
     }

--- a/crates/ticgit/src/commands/tui.rs
+++ b/crates/ticgit/src/commands/tui.rs
@@ -177,6 +177,8 @@ struct App {
     writeups: Vec<Writeup>,
     visible_writeups: Vec<usize>,
     list_state: ListState,
+    outline_state: ListState,
+    outline_collapsed: BTreeSet<uuid::Uuid>,
     writeup_state: ListState,
     board_column: usize,
     board_rows: [usize; BOARD_STATES.len()],
@@ -221,6 +223,7 @@ struct App {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ViewMode {
     List,
+    Outline,
     Board,
 }
 
@@ -340,7 +343,16 @@ struct NewTicketDraft {
     description: String,
     tags: String,
     assigned: String,
+    parent: Option<uuid::Uuid>,
     field: NewTicketField,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OutlineRow {
+    ticket_idx: usize,
+    depth: usize,
+    has_children: bool,
+    collapsed: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -369,6 +381,8 @@ impl App {
             writeups: Vec::new(),
             visible_writeups: Vec::new(),
             list_state: ListState::default(),
+            outline_state: ListState::default(),
+            outline_collapsed: BTreeSet::new(),
             writeup_state: ListState::default(),
             board_column: 0,
             board_rows: [0; BOARD_STATES.len()],
@@ -550,7 +564,7 @@ impl App {
                 self.draw_comments_list(frame, panes[0]);
                 self.draw_comment_detail(frame, panes[1]);
             } else {
-                self.draw_list(frame, panes[0]);
+                self.draw_issue_view(frame, panes[0]);
                 self.draw_detail(frame, panes[1]);
             }
         } else if self.active_tab == TuiTab::Writeups && self.writeup_detail.is_some() {
@@ -568,6 +582,7 @@ impl App {
             match self.active_tab {
                 TuiTab::Issues => match self.view {
                     ViewMode::List => self.draw_list(frame, outer[0]),
+                    ViewMode::Outline => self.draw_outline(frame, outer[0]),
                     ViewMode::Board => self.draw_board(frame, outer[0]),
                 },
                 TuiTab::Writeups => self.draw_writeup_list(frame, outer[0]),
@@ -1052,6 +1067,10 @@ impl App {
                             desc: "list",
                         },
                         MenuHint {
+                            key: "u",
+                            desc: "outline",
+                        },
+                        MenuHint {
                             key: "s",
                             desc: "state",
                         },
@@ -1080,6 +1099,45 @@ impl App {
                             desc: "quit",
                         },
                     ]
+                } else if self.view == ViewMode::Outline && self.detail.is_none() {
+                    vec![
+                        MenuHint {
+                            key: "Tab",
+                            desc: "writeups",
+                        },
+                        MenuHint {
+                            key: "j/k",
+                            desc: "tickets",
+                        },
+                        MenuHint {
+                            key: "Space",
+                            desc: "collapse",
+                        },
+                        MenuHint {
+                            key: "Enter",
+                            desc: "details",
+                        },
+                        MenuHint {
+                            key: "u",
+                            desc: "list",
+                        },
+                        MenuHint {
+                            key: "b",
+                            desc: "board",
+                        },
+                        MenuHint {
+                            key: "n",
+                            desc: "new",
+                        },
+                        MenuHint {
+                            key: "r",
+                            desc: "refresh",
+                        },
+                        MenuHint {
+                            key: "q",
+                            desc: "quit",
+                        },
+                    ]
                 } else if self.detail.is_some() {
                     vec![
                         MenuHint {
@@ -1093,6 +1151,18 @@ impl App {
                         MenuHint {
                             key: "b",
                             desc: "board",
+                        },
+                        MenuHint {
+                            key: "u",
+                            desc: "outline",
+                        },
+                        MenuHint {
+                            key: "n",
+                            desc: "subissue",
+                        },
+                        MenuHint {
+                            key: "P",
+                            desc: "parent",
                         },
                         MenuHint {
                             key: "+/-",
@@ -1180,6 +1250,10 @@ impl App {
                         MenuHint {
                             key: "b",
                             desc: "board",
+                        },
+                        MenuHint {
+                            key: "u",
+                            desc: "outline",
                         },
                         MenuHint {
                             key: "n",
@@ -1281,6 +1355,62 @@ impl App {
             .highlight_symbol(HIGHLIGHT_SYMBOL)
             .highlight_spacing(HighlightSpacing::Always);
         frame.render_stateful_widget(list, chunks[1], &mut self.list_state);
+    }
+
+    fn draw_issue_view(&mut self, frame: &mut Frame<'_>, area: Rect) {
+        match self.view {
+            ViewMode::List | ViewMode::Board => self.draw_list(frame, area),
+            ViewMode::Outline => self.draw_outline(frame, area),
+        }
+    }
+
+    fn draw_outline(&mut self, frame: &mut Frame<'_>, area: Rect) {
+        let rows = self.outline_rows();
+        let filter = self.active_filter_display();
+        let title = if filter.is_empty() {
+            format!("Issue outline ({})", self.visible.len())
+        } else {
+            format!("Issue outline matching {filter} ({})", self.visible.len())
+        };
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(tabs_title(self.active_tab, &title));
+        let row_width = usize::from(block.inner(area).width)
+            .saturating_sub(UnicodeWidthStr::width(HIGHLIGHT_SYMBOL));
+
+        let items: Vec<ListItem<'_>> = if rows.is_empty() {
+            vec![ListItem::new(Line::from(Span::styled(
+                "No issues match the current filters.",
+                Style::default().fg(Color::DarkGray),
+            )))]
+        } else {
+            rows.iter()
+                .map(|row| {
+                    let ticket = &self.tickets[row.ticket_idx];
+                    ListItem::new(outline_ticket_line(
+                        ticket,
+                        row.depth,
+                        row.has_children,
+                        row.collapsed,
+                        row_width,
+                        self.store.email(),
+                        !self.linked_writeups(ticket.id).is_empty(),
+                    ))
+                })
+                .collect()
+        };
+
+        let list = List::new(items)
+            .block(block)
+            .highlight_style(
+                Style::default()
+                    .bg(Color::Rgb(0, 0, 95))
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol(HIGHLIGHT_SYMBOL)
+            .highlight_spacing(HighlightSpacing::Always);
+        frame.render_stateful_widget(list, area, &mut self.outline_state);
     }
 
     fn draw_writeup_list(&mut self, frame: &mut Frame<'_>, area: Rect) {
@@ -1437,6 +1567,18 @@ impl App {
         }
         if let Some(closed_by) = &ticket.closed_by {
             detail_lines.push(field_line("Closed by", closed_by));
+        }
+        if let Some(parent) = ticket.parent {
+            detail_lines.push(field_line("Parent", &self.issue_label(parent)));
+        }
+        if !ticket.children.is_empty() {
+            detail_lines.push(field_line(
+                "Sub-issues",
+                &format!("{} (press u for outline)", ticket.children.len()),
+            ));
+            for child in ticket.children.iter().take(5) {
+                detail_lines.push(detail_child_issue_line(&self.issue_label(*child)));
+            }
         }
         if let Some(priority) = ticket.priority {
             detail_lines.push(field_line("Priority", &priority.to_string()));
@@ -2334,8 +2476,18 @@ impl App {
     }
 
     fn draw_create_modal(&self, frame: &mut Frame<'_>) {
-        let area = centered_rect(72, 15, frame.area());
-        let lines = vec![
+        let height = if self.new_ticket.parent.is_some() {
+            17
+        } else {
+            15
+        };
+        let area = centered_rect(72, height, frame.area());
+        let mut lines = Vec::new();
+        if let Some(parent_id) = self.new_ticket.parent {
+            lines.push(field_line("Parent", &self.issue_label(parent_id)));
+            lines.push(Line::raw(""));
+        }
+        lines.extend([
             new_ticket_field_line(
                 NewTicketField::Title,
                 self.new_ticket.field,
@@ -2369,9 +2521,14 @@ impl App {
                 "Tab/Up/Down switch fields  Enter create  Esc cancel",
                 Style::default().fg(Color::Yellow),
             )),
-        ];
+        ]);
+        let title = if self.new_ticket.parent.is_some() {
+            "New sub-issue"
+        } else {
+            "New ticket"
+        };
         let modal = Paragraph::new(lines)
-            .block(Block::default().borders(Borders::ALL).title("New ticket"))
+            .block(Block::default().borders(Borders::ALL).title(title))
             .wrap(Wrap { trim: false });
         frame.render_widget(Clear, area);
         frame.render_widget(modal, area);
@@ -2581,6 +2738,25 @@ impl App {
                 lines.push(help_columns(("c", "comment"), Some(("t", "manage tags"))));
                 lines.push(help_columns(("p", "priority"), Some(("o", "order"))));
             }
+            Mode::Normal if self.view == ViewMode::Outline && self.detail.is_none() => {
+                help_section(&mut lines, "Outline");
+                lines.push(help_columns(
+                    ("j/k", "move tickets"),
+                    Some(("Space", "collapse / expand")),
+                ));
+                lines.push(help_columns(("Enter", "details"), Some(("u", "list view"))));
+                lines.push(help_columns(("b", "board view"), Some(("n", "new ticket"))));
+                lines.push(help_columns(("r", "refresh"), None));
+
+                help_section(&mut lines, "Edit Ticket");
+                lines.push(help_columns(("C", "claim"), Some(("s", "state"))));
+                lines.push(help_columns(
+                    ("e", "edit title/body"),
+                    Some(("i", "edit spec")),
+                ));
+                lines.push(help_columns(("c", "comment"), Some(("t", "manage tags"))));
+                lines.push(help_columns(("p", "priority"), Some(("o", "order"))));
+            }
             Mode::Normal => {
                 help_section(&mut lines, "Navigation");
                 lines.push(help_columns(
@@ -2595,7 +2771,11 @@ impl App {
                     ("Enter", "details"),
                     Some(("b", "board view")),
                 ));
-                lines.push(help_columns(("m", "comments"), Some(("n", "new ticket"))));
+                lines.push(help_columns(
+                    ("u", "outline view"),
+                    Some(("n", "new/subissue")),
+                ));
+                lines.push(help_columns(("P", "jump parent"), Some(("m", "comments"))));
                 lines.push(help_columns(("+/-", "resize detail"), None));
                 lines.push(help_columns(("r", "refresh"), None));
 
@@ -2742,7 +2922,7 @@ impl App {
                     self.detail = None;
                     self.comments_mode = false;
                     false
-                } else if self.view == ViewMode::Board {
+                } else if matches!(self.view, ViewMode::Board | ViewMode::Outline) {
                     self.view = ViewMode::List;
                     false
                 } else if self.has_active_view_filters() {
@@ -2789,7 +2969,15 @@ impl App {
             }
             KeyCode::Char('b') => {
                 if self.active_tab == TuiTab::Issues {
-                    self.handle_board_key();
+                    self.handle_board_key()?;
+                }
+                false
+            }
+            KeyCode::Char('u') => {
+                if self.active_tab == TuiTab::Issues {
+                    self.handle_outline_key()?;
+                } else if self.active_tab == TuiTab::Writeups && self.writeup_detail.is_some() {
+                    self.begin_unlink_issue_select();
                 }
                 false
             }
@@ -2799,7 +2987,11 @@ impl App {
             }
             KeyCode::Char('n') => {
                 if self.active_tab == TuiTab::Issues {
-                    self.begin_create();
+                    if let Some(parent_id) = self.detail.map(|idx| self.tickets[idx].id) {
+                        self.begin_create_subissue(parent_id);
+                    } else {
+                        self.begin_create();
+                    }
                 } else {
                     self.create_writeup_in_editor(terminal)?;
                 }
@@ -2813,6 +3005,8 @@ impl App {
                     && self.detail.is_none()
                 {
                     self.next_board_ticket();
+                } else if self.active_tab == TuiTab::Issues && self.view == ViewMode::Outline {
+                    self.next_outline_ticket();
                 } else {
                     self.next();
                 }
@@ -2826,6 +3020,8 @@ impl App {
                     && self.detail.is_none()
                 {
                     self.previous_board_ticket();
+                } else if self.active_tab == TuiTab::Issues && self.view == ViewMode::Outline {
+                    self.previous_outline_ticket();
                 } else {
                     self.previous();
                 }
@@ -2839,6 +3035,11 @@ impl App {
                     && self.detail.is_none()
                 {
                     self.next_board_column();
+                } else if self.active_tab == TuiTab::Issues
+                    && self.view == ViewMode::Outline
+                    && self.detail.is_none()
+                {
+                    self.expand_selected_outline_node();
                 }
                 false
             }
@@ -2848,6 +3049,20 @@ impl App {
                     && self.detail.is_none()
                 {
                     self.previous_board_column();
+                } else if self.active_tab == TuiTab::Issues
+                    && self.view == ViewMode::Outline
+                    && self.detail.is_none()
+                {
+                    self.collapse_selected_outline_node();
+                }
+                false
+            }
+            KeyCode::Char(' ') => {
+                if self.active_tab == TuiTab::Issues
+                    && self.view == ViewMode::Outline
+                    && self.detail.is_none()
+                {
+                    self.toggle_selected_outline_node();
                 }
                 false
             }
@@ -2897,6 +3112,12 @@ impl App {
                 }
                 false
             }
+            KeyCode::Char('P') => {
+                if self.active_tab == TuiTab::Issues {
+                    self.jump_to_parent_issue();
+                }
+                false
+            }
             KeyCode::Char('o') => {
                 if self.active_tab == TuiTab::Issues {
                     self.begin_order();
@@ -2923,12 +3144,6 @@ impl App {
             }
             KeyCode::Char('-') => {
                 self.resize_detail(-(DETAIL_WIDTH_PERCENT_STEP as i16));
-                false
-            }
-            KeyCode::Char('u') => {
-                if self.active_tab == TuiTab::Writeups && self.writeup_detail.is_some() {
-                    self.begin_unlink_issue_select();
-                }
                 false
             }
             KeyCode::Char('s') => {
@@ -3249,6 +3464,14 @@ impl App {
 
     fn begin_create(&mut self) {
         self.new_ticket = NewTicketDraft::default();
+        self.mode = Mode::Create;
+    }
+
+    fn begin_create_subissue(&mut self, parent_id: uuid::Uuid) {
+        self.new_ticket = NewTicketDraft {
+            parent: Some(parent_id),
+            ..Default::default()
+        };
         self.mode = Mode::Create;
     }
 
@@ -3818,6 +4041,23 @@ impl App {
         }
     }
 
+    fn jump_to_parent_issue(&mut self) {
+        let Some(ticket) = self.detail.map(|idx| &self.tickets[idx]) else {
+            self.status = Some("Open ticket details first.".to_string());
+            return;
+        };
+        let Some(parent) = ticket.parent else {
+            self.status = Some("This issue has no parent.".to_string());
+            return;
+        };
+        self.open_ticket_by_id(parent);
+        if self.detail.map(|idx| self.tickets[idx].id) == Some(parent) {
+            self.status = Some(format!("Opened parent {}.", self.issue_label(parent)));
+        } else {
+            self.status = Some("Parent issue is hidden by current filters.".to_string());
+        }
+    }
+
     fn start_sync(&mut self) {
         if self.sync.is_some() {
             self.status = Some("Sync already running.".to_string());
@@ -4160,6 +4400,17 @@ impl App {
         )
     }
 
+    fn issue_label(&self, id: uuid::Uuid) -> String {
+        let short_id = id.to_string().chars().take(6).collect::<String>();
+        let title = self
+            .all_tickets
+            .iter()
+            .find(|ticket| ticket.id == id)
+            .map(|ticket| flatten_display(&ticket.title))
+            .unwrap_or_else(|| "missing issue".to_string());
+        format!("{short_id} {title}")
+    }
+
     fn unlink_selected_issue(&mut self) -> Result<bool> {
         let Some(writeup) = self.selected_writeup() else {
             self.status = Some("Select a writeup first.".to_string());
@@ -4293,6 +4544,7 @@ impl App {
                 comment: None,
                 tags: split_tags(&self.new_ticket.tags),
                 assigned: optional_trimmed(&self.new_ticket.assigned).map(ToString::to_string),
+                parent: self.new_ticket.parent,
                 ..Default::default()
             },
         )?;
@@ -4302,6 +4554,9 @@ impl App {
         }
 
         self.filter.clear();
+        if self.new_ticket.parent.is_some() {
+            self.hide_subissues = false;
+        }
         self.detail = Some(0);
         self.reload(Some(id))?;
         self.open_ticket_by_id(id);
@@ -4611,6 +4866,7 @@ impl App {
                 .min(self.visible.len() - 1);
             self.list_state.select(Some(selected));
         }
+        self.sync_outline_selection();
         self.apply_writeup_filter();
     }
 
@@ -4704,6 +4960,96 @@ impl App {
         self.sync_open_writeup_detail();
     }
 
+    fn outline_rows(&self) -> Vec<OutlineRow> {
+        build_outline_rows(&self.tickets, &self.visible, &self.outline_collapsed)
+    }
+
+    fn selected_outline_row(&self) -> Option<OutlineRow> {
+        self.outline_state
+            .selected()
+            .and_then(|selected| self.outline_rows().get(selected).copied())
+    }
+
+    fn next_outline_ticket(&mut self) {
+        let rows = self.outline_rows();
+        if rows.is_empty() {
+            self.outline_state.select(None);
+            return;
+        }
+        let selected = self.outline_state.selected().unwrap_or(0);
+        self.outline_state.select(Some((selected + 1) % rows.len()));
+        self.sync_outline_to_list_selection();
+        self.sync_open_detail();
+    }
+
+    fn previous_outline_ticket(&mut self) {
+        let rows = self.outline_rows();
+        if rows.is_empty() {
+            self.outline_state.select(None);
+            return;
+        }
+        let selected = self.outline_state.selected().unwrap_or(0);
+        let previous = selected
+            .checked_sub(1)
+            .unwrap_or_else(|| rows.len().saturating_sub(1));
+        self.outline_state.select(Some(previous));
+        self.sync_outline_to_list_selection();
+        self.sync_open_detail();
+    }
+
+    fn toggle_selected_outline_node(&mut self) {
+        let Some(row) = self.selected_outline_row() else {
+            return;
+        };
+        if !row.has_children {
+            return;
+        }
+        let id = self.tickets[row.ticket_idx].id;
+        if !self.outline_collapsed.remove(&id) {
+            self.outline_collapsed.insert(id);
+        }
+        self.sync_outline_selection();
+    }
+
+    fn expand_selected_outline_node(&mut self) {
+        let Some(row) = self.selected_outline_row() else {
+            return;
+        };
+        if row.has_children {
+            let id = self.tickets[row.ticket_idx].id;
+            self.outline_collapsed.remove(&id);
+            self.sync_outline_selection();
+        }
+    }
+
+    fn collapse_selected_outline_node(&mut self) {
+        let Some(row) = self.selected_outline_row() else {
+            return;
+        };
+        if row.has_children {
+            let id = self.tickets[row.ticket_idx].id;
+            self.outline_collapsed.insert(id);
+            self.sync_outline_selection();
+            return;
+        }
+
+        if row.depth == 0 {
+            return;
+        }
+        let Some(parent) = self.tickets[row.ticket_idx].parent else {
+            return;
+        };
+        if let Some(parent_row) = self
+            .outline_rows()
+            .iter()
+            .position(|candidate| self.tickets[candidate.ticket_idx].id == parent)
+        {
+            self.outline_state.select(Some(parent_row));
+            self.sync_outline_to_list_selection();
+            self.sync_open_detail();
+        }
+    }
+
     fn resize_detail(&mut self, delta: i16) {
         if self.detail.is_none() && self.writeup_detail.is_none() {
             self.status = Some("Open details first.".to_string());
@@ -4739,10 +5085,15 @@ impl App {
         let selected_id = self.selected_ticket().map(|ticket| ticket.id);
         let selected_writeup_id = self.selected_writeup().map(|writeup| writeup.id);
         let was_board = self.view == ViewMode::Board && self.detail.is_none();
+        let was_outline = self.view == ViewMode::Outline;
         self.reload_all(selected_id, selected_writeup_id)?;
         if was_board {
             if let Some(id) = selected_id {
                 self.select_board_ticket_by_id(id);
+            }
+        } else if was_outline {
+            if let Some(id) = selected_id {
+                self.select_outline_ticket_by_id(id);
             }
         }
         self.status = Some("Refreshed.".to_string());
@@ -4761,12 +5112,16 @@ impl App {
         };
     }
 
-    fn toggle_view(&mut self) {
-        self.view = match self.view {
-            ViewMode::List => ViewMode::Board,
-            ViewMode::Board => ViewMode::List,
+    fn select_outline_ticket_by_id(&mut self, id: uuid::Uuid) {
+        let Some(row) = self
+            .outline_rows()
+            .iter()
+            .position(|row| self.tickets[row.ticket_idx].id == id)
+        else {
+            return;
         };
-        self.sync_board_to_list_selection();
+        self.outline_state.select(Some(row));
+        self.sync_outline_to_list_selection();
     }
 
     fn select_board_ticket_by_id(&mut self, id: uuid::Uuid) {
@@ -4788,12 +5143,39 @@ impl App {
         self.board_rows[column] = row;
     }
 
-    fn handle_board_key(&mut self) {
+    fn handle_board_key(&mut self) -> Result<()> {
         if self.detail.is_some() {
             self.open_board_for_detail_ticket();
+        } else if self.view == ViewMode::Board {
+            self.view = ViewMode::List;
         } else {
-            self.toggle_view();
+            let selected_id = self.selected_ticket().map(|ticket| ticket.id);
+            self.view = ViewMode::Board;
+            if let Some(id) = selected_id {
+                self.select_board_ticket_by_id(id);
+            }
         }
+        Ok(())
+    }
+
+    fn handle_outline_key(&mut self) -> Result<()> {
+        let selected_id = self.selected_ticket().map(|ticket| ticket.id);
+        if self.view == ViewMode::Outline && self.detail.is_none() {
+            self.view = ViewMode::List;
+            self.sync_outline_to_list_selection();
+            return Ok(());
+        }
+        if self.hide_subissues {
+            self.hide_subissues = false;
+            self.reload(selected_id)?;
+        }
+        self.view = ViewMode::Outline;
+        self.detail = None;
+        self.comments_mode = false;
+        if let Some(id) = selected_id {
+            self.select_outline_ticket_by_id(id);
+        }
+        Ok(())
     }
 
     fn open_board_for_detail_ticket(&mut self) {
@@ -4833,6 +5215,9 @@ impl App {
             if let Some(visible_pos) = self.visible.iter().position(|visible| *visible == idx) {
                 self.list_state.select(Some(visible_pos));
             }
+            if self.view == ViewMode::Outline {
+                self.select_outline_ticket_by_id(self.tickets[idx].id);
+            }
             self.comments_mode = false;
             self.sync_comment_selection();
         }
@@ -4860,6 +5245,9 @@ impl App {
             self.list_state.select(Some(visible_pos));
             self.detail = self.visible.get(visible_pos).copied();
             self.comments_mode = false;
+            if self.view == ViewMode::Outline {
+                self.select_outline_ticket_by_id(id);
+            }
             self.sync_comment_selection();
         }
     }
@@ -4931,6 +5319,32 @@ impl App {
     fn sync_board_to_list_selection(&mut self) {
         if let Some(idx) = self.selected_ticket_index() {
             if let Some(visible_pos) = self.visible.iter().position(|visible| *visible == idx) {
+                self.list_state.select(Some(visible_pos));
+            }
+        }
+    }
+
+    fn sync_outline_selection(&mut self) {
+        let rows = self.outline_rows();
+        if rows.is_empty() {
+            self.outline_state.select(None);
+            return;
+        }
+        let selected = self
+            .outline_state
+            .selected()
+            .unwrap_or(0)
+            .min(rows.len() - 1);
+        self.outline_state.select(Some(selected));
+    }
+
+    fn sync_outline_to_list_selection(&mut self) {
+        if let Some(row) = self.selected_outline_row() {
+            if let Some(visible_pos) = self
+                .visible
+                .iter()
+                .position(|visible| *visible == row.ticket_idx)
+            {
                 self.list_state.select(Some(visible_pos));
             }
         }
@@ -5030,6 +5444,9 @@ impl App {
             return tickets
                 .get(self.board_rows[self.board_column])
                 .map(|idx| **idx);
+        }
+        if self.view == ViewMode::Outline {
+            return self.selected_outline_row().map(|row| row.ticket_idx);
         }
         self.list_state
             .selected()
@@ -5361,6 +5778,180 @@ fn ticket_list_line(
         width,
         has_writeups.then(|| ("[w]".to_string(), Style::default().fg(Color::Yellow))),
     )
+}
+
+fn outline_ticket_line(
+    ticket: &Ticket,
+    depth: usize,
+    has_children: bool,
+    collapsed: bool,
+    width: usize,
+    current_user: &str,
+    has_writeups: bool,
+) -> Line<'static> {
+    let indent_width = depth.saturating_mul(2).min(width);
+    let marker = match (has_children, collapsed) {
+        (true, true) => "+",
+        (true, false) => "-",
+        (false, _) => " ",
+    };
+    let marker_width = UnicodeWidthStr::width(marker);
+    let gap_width = usize::from(width > indent_width + marker_width);
+    let prefix_width = indent_width + marker_width + gap_width;
+    let mut spans = vec![
+        Span::raw(" ".repeat(indent_width)),
+        Span::styled(marker.to_string(), Style::default().fg(Color::Yellow)),
+        Span::raw(" ".repeat(gap_width)),
+    ];
+    let content = ticket_list_line(
+        ticket,
+        width.saturating_sub(prefix_width),
+        true,
+        current_user,
+        has_writeups,
+    );
+    spans.extend(content.spans);
+    Line::from(spans)
+}
+
+fn build_outline_rows(
+    tickets: &[Ticket],
+    visible: &[usize],
+    collapsed: &BTreeSet<uuid::Uuid>,
+) -> Vec<OutlineRow> {
+    let visible_set = visible.iter().copied().collect::<BTreeSet<_>>();
+    let visible_order = visible
+        .iter()
+        .enumerate()
+        .map(|(order, idx)| (*idx, order))
+        .collect::<HashMap<_, _>>();
+    let index_by_id = tickets
+        .iter()
+        .enumerate()
+        .map(|(idx, ticket)| (ticket.id, idx))
+        .collect::<HashMap<_, _>>();
+
+    let mut roots = Vec::new();
+    let mut children_by_parent = HashMap::<uuid::Uuid, Vec<usize>>::new();
+    for &idx in visible {
+        let Some(ticket) = tickets.get(idx) else {
+            continue;
+        };
+        if let Some(parent) = ticket.parent {
+            if index_by_id
+                .get(&parent)
+                .is_some_and(|parent_idx| visible_set.contains(parent_idx))
+            {
+                children_by_parent.entry(parent).or_default().push(idx);
+                continue;
+            }
+        }
+        roots.push(idx);
+    }
+
+    roots.sort_by_key(|idx| visible_order.get(idx).copied().unwrap_or(usize::MAX));
+    for children in children_by_parent.values_mut() {
+        children.sort_by_key(|idx| visible_order.get(idx).copied().unwrap_or(usize::MAX));
+    }
+
+    let mut rows = Vec::new();
+    let mut visited = BTreeSet::<uuid::Uuid>::new();
+    for idx in roots {
+        push_outline_row(
+            tickets,
+            idx,
+            0,
+            collapsed,
+            &children_by_parent,
+            &mut visited,
+            &mut rows,
+        );
+    }
+    for &idx in visible {
+        let Some(ticket) = tickets.get(idx) else {
+            continue;
+        };
+        if visited.contains(&ticket.id) {
+            continue;
+        }
+        push_outline_row(
+            tickets,
+            idx,
+            0,
+            collapsed,
+            &children_by_parent,
+            &mut visited,
+            &mut rows,
+        );
+    }
+
+    rows
+}
+
+fn push_outline_row(
+    tickets: &[Ticket],
+    idx: usize,
+    depth: usize,
+    collapsed: &BTreeSet<uuid::Uuid>,
+    children_by_parent: &HashMap<uuid::Uuid, Vec<usize>>,
+    visited: &mut BTreeSet<uuid::Uuid>,
+    rows: &mut Vec<OutlineRow>,
+) {
+    let Some(ticket) = tickets.get(idx) else {
+        return;
+    };
+    if !visited.insert(ticket.id) {
+        return;
+    }
+
+    let children = children_by_parent.get(&ticket.id);
+    let has_children = children.is_some_and(|children| !children.is_empty());
+    let is_collapsed = collapsed.contains(&ticket.id);
+    rows.push(OutlineRow {
+        ticket_idx: idx,
+        depth,
+        has_children,
+        collapsed: is_collapsed,
+    });
+
+    if is_collapsed {
+        if let Some(children) = children {
+            mark_outline_descendants_visited(tickets, children, children_by_parent, visited);
+        }
+        return;
+    }
+    if let Some(children) = children {
+        for &child in children {
+            push_outline_row(
+                tickets,
+                child,
+                depth + 1,
+                collapsed,
+                children_by_parent,
+                visited,
+                rows,
+            );
+        }
+    }
+}
+
+fn mark_outline_descendants_visited(
+    tickets: &[Ticket],
+    children: &[usize],
+    children_by_parent: &HashMap<uuid::Uuid, Vec<usize>>,
+    visited: &mut BTreeSet<uuid::Uuid>,
+) {
+    for &child in children {
+        let Some(ticket) = tickets.get(child) else {
+            continue;
+        };
+        if !visited.insert(ticket.id) {
+            continue;
+        }
+        if let Some(grandchildren) = children_by_parent.get(&ticket.id) {
+            mark_outline_descendants_visited(tickets, grandchildren, children_by_parent, visited);
+        }
+    }
 }
 
 fn issue_columns_for_width(columns: &[IssueColumn], width: usize) -> Vec<IssueColumn> {
@@ -6671,6 +7262,13 @@ fn field_line(label: &str, value: &str) -> Line<'static> {
     ])
 }
 
+fn detail_child_issue_line(value: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::raw(" ".repeat(13)),
+        Span::styled(value.to_string(), Style::default().fg(Color::Cyan)),
+    ])
+}
+
 #[derive(Clone)]
 struct MetadataField {
     key: &'static str,
@@ -7091,5 +7689,81 @@ mod tests {
 
         assert_eq!(spans_width(&spans), 8);
         assert!(spans.iter().any(|span| span.content.as_ref() == "bug"));
+    }
+
+    #[test]
+    fn outline_rows_indent_visible_subissues() {
+        let root = uuid::Uuid::from_u128(1);
+        let child = uuid::Uuid::from_u128(2);
+        let grandchild = uuid::Uuid::from_u128(3);
+        let sibling = uuid::Uuid::from_u128(4);
+        let tickets = vec![
+            test_ticket(root, None, &[child]),
+            test_ticket(child, Some(root), &[grandchild]),
+            test_ticket(grandchild, Some(child), &[]),
+            test_ticket(sibling, None, &[]),
+        ];
+
+        let rows = build_outline_rows(&tickets, &[0, 1, 2, 3], &BTreeSet::new());
+
+        assert_eq!(
+            rows.iter()
+                .map(|row| (tickets[row.ticket_idx].id, row.depth, row.has_children))
+                .collect::<Vec<_>>(),
+            vec![
+                (root, 0, true),
+                (child, 1, true),
+                (grandchild, 2, false),
+                (sibling, 0, false)
+            ]
+        );
+    }
+
+    #[test]
+    fn outline_rows_hide_descendants_under_collapsed_parent() {
+        let root = uuid::Uuid::from_u128(1);
+        let child = uuid::Uuid::from_u128(2);
+        let sibling = uuid::Uuid::from_u128(3);
+        let tickets = vec![
+            test_ticket(root, None, &[child]),
+            test_ticket(child, Some(root), &[]),
+            test_ticket(sibling, None, &[]),
+        ];
+        let collapsed = BTreeSet::from([root]);
+
+        let rows = build_outline_rows(&tickets, &[0, 1, 2], &collapsed);
+
+        assert_eq!(
+            rows.iter()
+                .map(|row| (tickets[row.ticket_idx].id, row.depth, row.collapsed))
+                .collect::<Vec<_>>(),
+            vec![(root, 0, true), (sibling, 0, false)]
+        );
+    }
+
+    fn test_ticket(id: uuid::Uuid, parent: Option<uuid::Uuid>, children: &[uuid::Uuid]) -> Ticket {
+        Ticket {
+            id,
+            title: format!("Ticket {id}"),
+            description: None,
+            spec: None,
+            status: TicketStatus::Open,
+            state: TicketState::New,
+            assigned: None,
+            closed_by: None,
+            priority: None,
+            points: None,
+            milestone: None,
+            code: None,
+            parent,
+            children: children.iter().copied().collect(),
+            depends_on: BTreeSet::new(),
+            blocks: BTreeSet::new(),
+            tags: BTreeSet::new(),
+            meta: BTreeMap::new(),
+            comments: Vec::new(),
+            created_at: OffsetDateTime::UNIX_EPOCH,
+            created_by: "test@example.com".to_string(),
+        }
     }
 }

--- a/crates/ticgit/src/commands/tui.rs
+++ b/crates/ticgit/src/commands/tui.rs
@@ -973,6 +973,10 @@ impl App {
                             desc: "issues",
                         },
                         MenuHint {
+                            key: "d",
+                            desc: "issues",
+                        },
+                        MenuHint {
                             key: "r",
                             desc: "refresh",
                         },
@@ -1024,6 +1028,10 @@ impl App {
                             desc: "all/open",
                         },
                         MenuHint {
+                            key: "d",
+                            desc: "stats",
+                        },
+                        MenuHint {
                             key: "c/o",
                             desc: "close/open",
                         },
@@ -1065,6 +1073,10 @@ impl App {
                         MenuHint {
                             key: "b",
                             desc: "list",
+                        },
+                        MenuHint {
+                            key: "d",
+                            desc: "stats",
                         },
                         MenuHint {
                             key: "u",
@@ -1126,6 +1138,10 @@ impl App {
                             desc: "board",
                         },
                         MenuHint {
+                            key: "d",
+                            desc: "stats",
+                        },
+                        MenuHint {
                             key: "n",
                             desc: "new",
                         },
@@ -1151,6 +1167,10 @@ impl App {
                         MenuHint {
                             key: "b",
                             desc: "board",
+                        },
+                        MenuHint {
+                            key: "d",
+                            desc: "stats",
                         },
                         MenuHint {
                             key: "u",
@@ -1250,6 +1270,10 @@ impl App {
                         MenuHint {
                             key: "b",
                             desc: "board",
+                        },
+                        MenuHint {
+                            key: "d",
+                            desc: "stats",
                         },
                         MenuHint {
                             key: "u",
@@ -2710,11 +2734,17 @@ impl App {
                     ("+/-", "resize detail"),
                     Some(("r", "refresh")),
                 ));
+
+                help_section(&mut lines, "Views");
+                lines.push(help_columns(("d", "stats view"), None));
             }
             Mode::Normal if self.active_tab == TuiTab::Dashboard => {
                 help_section(&mut lines, "Dashboard");
                 lines.push(help_columns(("Tab", "issues tab"), Some(("r", "refresh"))));
                 lines.push(help_columns(("S", "sync tickets"), Some(("q", "quit"))));
+
+                help_section(&mut lines, "Views");
+                lines.push(help_columns(("d", "issues view"), None));
             }
             Mode::Normal if self.view == ViewMode::Board && self.detail.is_none() => {
                 help_section(&mut lines, "Navigation");
@@ -2726,8 +2756,7 @@ impl App {
                     ("Left/Right", "move columns"),
                     Some(("Up/Down", "move tickets")),
                 ));
-                lines.push(help_columns(("Enter", "details"), Some(("b", "list view"))));
-                lines.push(help_columns(("r", "refresh"), None));
+                lines.push(help_columns(("Enter", "details"), Some(("r", "refresh"))));
 
                 help_section(&mut lines, "Edit Ticket");
                 lines.push(help_columns(("C", "claim"), Some(("s", "state"))));
@@ -2737,6 +2766,10 @@ impl App {
                 ));
                 lines.push(help_columns(("c", "comment"), Some(("t", "manage tags"))));
                 lines.push(help_columns(("p", "priority"), Some(("o", "order"))));
+
+                help_section(&mut lines, "Views");
+                lines.push(help_columns(("b", "list view"), Some(("d", "stats view"))));
+                lines.push(help_columns(("u", "outline view"), None));
             }
             Mode::Normal if self.view == ViewMode::Outline && self.detail.is_none() => {
                 help_section(&mut lines, "Outline");
@@ -2744,8 +2777,10 @@ impl App {
                     ("j/k", "move tickets"),
                     Some(("Space", "collapse / expand")),
                 ));
-                lines.push(help_columns(("Enter", "details"), Some(("u", "list view"))));
-                lines.push(help_columns(("b", "board view"), Some(("n", "new ticket"))));
+                lines.push(help_columns(
+                    ("Enter", "details"),
+                    Some(("n", "new ticket")),
+                ));
                 lines.push(help_columns(("r", "refresh"), None));
 
                 help_section(&mut lines, "Edit Ticket");
@@ -2756,6 +2791,10 @@ impl App {
                 ));
                 lines.push(help_columns(("c", "comment"), Some(("t", "manage tags"))));
                 lines.push(help_columns(("p", "priority"), Some(("o", "order"))));
+
+                help_section(&mut lines, "Views");
+                lines.push(help_columns(("u", "list view"), Some(("b", "board view"))));
+                lines.push(help_columns(("d", "stats view"), None));
             }
             Mode::Normal => {
                 help_section(&mut lines, "Navigation");
@@ -2769,17 +2808,13 @@ impl App {
                 ));
                 lines.push(help_columns(
                     ("Enter", "details"),
-                    Some(("b", "board view")),
-                ));
-                lines.push(help_columns(
-                    ("u", "outline view"),
                     Some(("n", "new/subissue")),
                 ));
                 lines.push(help_columns(("P", "jump parent"), Some(("m", "comments"))));
                 lines.push(help_columns(("+/-", "resize detail"), None));
                 lines.push(help_columns(("r", "refresh"), None));
 
-                help_section(&mut lines, "Views & Filters");
+                help_section(&mut lines, "Filters");
                 lines.push(help_columns(
                     ("/", "search text"),
                     Some(("g", "tag picker")),
@@ -2795,6 +2830,10 @@ impl App {
                 ));
                 lines.push(help_columns(("c", "comment"), Some(("t", "manage tags"))));
                 lines.push(help_columns(("p", "priority"), None));
+
+                help_section(&mut lines, "Views");
+                lines.push(help_columns(("b", "board view"), Some(("d", "stats view"))));
+                lines.push(help_columns(("u", "outline view"), None));
             }
         }
 
@@ -2971,6 +3010,10 @@ impl App {
                 if self.active_tab == TuiTab::Issues {
                     self.handle_board_key()?;
                 }
+                false
+            }
+            KeyCode::Char('d') => {
+                self.handle_dashboard_key();
                 false
             }
             KeyCode::Char('u') => {
@@ -5176,6 +5219,18 @@ impl App {
             self.select_outline_ticket_by_id(id);
         }
         Ok(())
+    }
+
+    fn handle_dashboard_key(&mut self) {
+        if self.active_tab == TuiTab::Dashboard {
+            self.active_tab = TuiTab::Issues;
+            self.view = ViewMode::List;
+            return;
+        }
+        self.active_tab = TuiTab::Dashboard;
+        self.detail = None;
+        self.writeup_detail = None;
+        self.comments_mode = false;
     }
 
     fn open_board_for_detail_ticket(&mut self) {

--- a/crates/ticgit/src/commands/tui.rs
+++ b/crates/ticgit/src/commands/tui.rs
@@ -177,8 +177,6 @@ struct App {
     writeups: Vec<Writeup>,
     visible_writeups: Vec<usize>,
     list_state: ListState,
-    outline_state: ListState,
-    outline_collapsed: BTreeSet<uuid::Uuid>,
     writeup_state: ListState,
     board_column: usize,
     board_rows: [usize; BOARD_STATES.len()],
@@ -224,7 +222,6 @@ struct App {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ViewMode {
     List,
-    Outline,
     Board,
 }
 
@@ -383,8 +380,6 @@ impl App {
             writeups: Vec::new(),
             visible_writeups: Vec::new(),
             list_state: ListState::default(),
-            outline_state: ListState::default(),
-            outline_collapsed: BTreeSet::new(),
             writeup_state: ListState::default(),
             board_column: 0,
             board_rows: [0; BOARD_STATES.len()],
@@ -585,7 +580,6 @@ impl App {
             match self.active_tab {
                 TuiTab::Issues => match self.view {
                     ViewMode::List => self.draw_list(frame, outer[0]),
-                    ViewMode::Outline => self.draw_outline(frame, outer[0]),
                     ViewMode::Board => self.draw_board(frame, outer[0]),
                 },
                 TuiTab::Writeups => self.draw_writeup_list(frame, outer[0]),
@@ -1082,10 +1076,6 @@ impl App {
                             desc: "stats",
                         },
                         MenuHint {
-                            key: "u",
-                            desc: "outline",
-                        },
-                        MenuHint {
                             key: "U",
                             desc: "subissues",
                         },
@@ -1118,53 +1108,6 @@ impl App {
                             desc: "quit",
                         },
                     ]
-                } else if self.view == ViewMode::Outline && self.detail.is_none() {
-                    vec![
-                        MenuHint {
-                            key: "Tab",
-                            desc: "writeups",
-                        },
-                        MenuHint {
-                            key: "j/k",
-                            desc: "tickets",
-                        },
-                        MenuHint {
-                            key: "Space",
-                            desc: "collapse",
-                        },
-                        MenuHint {
-                            key: "Enter",
-                            desc: "details",
-                        },
-                        MenuHint {
-                            key: "u",
-                            desc: "list",
-                        },
-                        MenuHint {
-                            key: "U",
-                            desc: "subissues",
-                        },
-                        MenuHint {
-                            key: "b",
-                            desc: "board",
-                        },
-                        MenuHint {
-                            key: "d",
-                            desc: "stats",
-                        },
-                        MenuHint {
-                            key: "n",
-                            desc: "new",
-                        },
-                        MenuHint {
-                            key: "r",
-                            desc: "refresh",
-                        },
-                        MenuHint {
-                            key: "q",
-                            desc: "quit",
-                        },
-                    ]
                 } else if self.detail.is_some() {
                     vec![
                         MenuHint {
@@ -1182,10 +1125,6 @@ impl App {
                         MenuHint {
                             key: "d",
                             desc: "stats",
-                        },
-                        MenuHint {
-                            key: "u",
-                            desc: "outline",
                         },
                         MenuHint {
                             key: "U",
@@ -1291,10 +1230,6 @@ impl App {
                             desc: "stats",
                         },
                         MenuHint {
-                            key: "u",
-                            desc: "outline",
-                        },
-                        MenuHint {
                             key: "U",
                             desc: "subissues",
                         },
@@ -1371,11 +1306,7 @@ impl App {
             .iter()
             .map(|&idx| {
                 let ticket = &self.tickets[idx];
-                let title_prefix = if self.hide_subissues {
-                    String::new()
-                } else {
-                    subissue_graph_prefix(ticket, &ticket_by_id)
-                };
+                let title_prefix = issue_title_prefix(ticket, &ticket_by_id, !self.hide_subissues);
                 ListItem::new(ticket_table_line(
                     ticket,
                     &columns,
@@ -1414,57 +1345,7 @@ impl App {
     fn draw_issue_view(&mut self, frame: &mut Frame<'_>, area: Rect) {
         match self.view {
             ViewMode::List | ViewMode::Board => self.draw_list(frame, area),
-            ViewMode::Outline => self.draw_outline(frame, area),
         }
-    }
-
-    fn draw_outline(&mut self, frame: &mut Frame<'_>, area: Rect) {
-        let rows = self.outline_rows();
-        let filter = self.active_filter_display();
-        let title = if filter.is_empty() {
-            format!("Issue outline ({})", self.visible.len())
-        } else {
-            format!("Issue outline matching {filter} ({})", self.visible.len())
-        };
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .title(tabs_title(self.active_tab, &title));
-        let row_width = usize::from(block.inner(area).width)
-            .saturating_sub(UnicodeWidthStr::width(HIGHLIGHT_SYMBOL));
-
-        let items: Vec<ListItem<'_>> = if rows.is_empty() {
-            vec![ListItem::new(Line::from(Span::styled(
-                "No issues match the current filters.",
-                Style::default().fg(Color::DarkGray),
-            )))]
-        } else {
-            rows.iter()
-                .map(|row| {
-                    let ticket = &self.tickets[row.ticket_idx];
-                    ListItem::new(outline_ticket_line(
-                        ticket,
-                        row.depth,
-                        row.has_children,
-                        row.collapsed,
-                        row_width,
-                        self.store.email(),
-                        !self.linked_writeups(ticket.id).is_empty(),
-                    ))
-                })
-                .collect()
-        };
-
-        let list = List::new(items)
-            .block(block)
-            .highlight_style(
-                Style::default()
-                    .bg(Color::Rgb(0, 0, 95))
-                    .fg(Color::White)
-                    .add_modifier(Modifier::BOLD),
-            )
-            .highlight_symbol(HIGHLIGHT_SYMBOL)
-            .highlight_spacing(HighlightSpacing::Always);
-        frame.render_stateful_widget(list, area, &mut self.outline_state);
     }
 
     fn draw_writeup_list(&mut self, frame: &mut Frame<'_>, area: Rect) {
@@ -1628,7 +1509,7 @@ impl App {
         if !ticket.children.is_empty() {
             detail_lines.push(field_line(
                 "Sub-issues",
-                &format!("{} (press u for outline)", ticket.children.len()),
+                &format!("{} (press U to show in list)", ticket.children.len()),
             ));
             for child in ticket.children.iter().take(5) {
                 detail_lines.push(detail_child_issue_line(&self.issue_label(*child)));
@@ -2799,35 +2680,7 @@ impl App {
 
                 help_section(&mut lines, "Views");
                 lines.push(help_columns(("b", "list view"), Some(("d", "stats view"))));
-                lines.push(help_columns(
-                    ("u", "outline view"),
-                    Some(("U", "subissues")),
-                ));
-            }
-            Mode::Normal if self.view == ViewMode::Outline && self.detail.is_none() => {
-                help_section(&mut lines, "Outline");
-                lines.push(help_columns(
-                    ("j/k", "move tickets"),
-                    Some(("Space", "collapse / expand")),
-                ));
-                lines.push(help_columns(
-                    ("Enter", "details"),
-                    Some(("n", "new ticket")),
-                ));
-                lines.push(help_columns(("r", "refresh"), None));
-
-                help_section(&mut lines, "Edit Ticket");
-                lines.push(help_columns(("C", "claim"), Some(("s", "state"))));
-                lines.push(help_columns(
-                    ("e", "edit title/body"),
-                    Some(("i", "edit spec")),
-                ));
-                lines.push(help_columns(("c", "comment"), Some(("t", "manage tags"))));
-                lines.push(help_columns(("p", "priority"), Some(("o", "order"))));
-
-                help_section(&mut lines, "Views");
-                lines.push(help_columns(("u", "list view"), Some(("b", "board view"))));
-                lines.push(help_columns(("d", "stats view"), Some(("U", "subissues"))));
+                lines.push(help_columns(("U", "subissues"), None));
             }
             Mode::Normal => {
                 help_section(&mut lines, "Navigation");
@@ -2866,10 +2719,7 @@ impl App {
 
                 help_section(&mut lines, "Views");
                 lines.push(help_columns(("b", "board view"), Some(("d", "stats view"))));
-                lines.push(help_columns(
-                    ("u", "outline view"),
-                    Some(("U", "subissues")),
-                ));
+                lines.push(help_columns(("U", "subissues"), None));
             }
         }
 
@@ -2997,7 +2847,7 @@ impl App {
                     self.detail = None;
                     self.comments_mode = false;
                     false
-                } else if matches!(self.view, ViewMode::Board | ViewMode::Outline) {
+                } else if self.view == ViewMode::Board {
                     self.view = ViewMode::List;
                     false
                 } else if self.has_active_view_filters() {
@@ -3053,9 +2903,7 @@ impl App {
                 false
             }
             KeyCode::Char('u') => {
-                if self.active_tab == TuiTab::Issues {
-                    self.handle_outline_key()?;
-                } else if self.active_tab == TuiTab::Writeups && self.writeup_detail.is_some() {
+                if self.active_tab == TuiTab::Writeups && self.writeup_detail.is_some() {
                     self.begin_unlink_issue_select();
                 }
                 false
@@ -3090,8 +2938,6 @@ impl App {
                     && self.detail.is_none()
                 {
                     self.next_board_ticket();
-                } else if self.active_tab == TuiTab::Issues && self.view == ViewMode::Outline {
-                    self.next_outline_ticket();
                 } else {
                     self.next();
                 }
@@ -3105,8 +2951,6 @@ impl App {
                     && self.detail.is_none()
                 {
                     self.previous_board_ticket();
-                } else if self.active_tab == TuiTab::Issues && self.view == ViewMode::Outline {
-                    self.previous_outline_ticket();
                 } else {
                     self.previous();
                 }
@@ -3120,11 +2964,6 @@ impl App {
                     && self.detail.is_none()
                 {
                     self.next_board_column();
-                } else if self.active_tab == TuiTab::Issues
-                    && self.view == ViewMode::Outline
-                    && self.detail.is_none()
-                {
-                    self.expand_selected_outline_node();
                 }
                 false
             }
@@ -3134,20 +2973,6 @@ impl App {
                     && self.detail.is_none()
                 {
                     self.previous_board_column();
-                } else if self.active_tab == TuiTab::Issues
-                    && self.view == ViewMode::Outline
-                    && self.detail.is_none()
-                {
-                    self.collapse_selected_outline_node();
-                }
-                false
-            }
-            KeyCode::Char(' ') => {
-                if self.active_tab == TuiTab::Issues
-                    && self.view == ViewMode::Outline
-                    && self.detail.is_none()
-                {
-                    self.toggle_selected_outline_node();
                 }
                 false
             }
@@ -4945,7 +4770,6 @@ impl App {
             let selected = self.list_state.selected().unwrap_or(0).min(list_len - 1);
             self.list_state.select(Some(selected));
         }
-        self.sync_outline_selection();
         self.apply_writeup_filter();
     }
 
@@ -5045,96 +4869,6 @@ impl App {
         self.sync_open_writeup_detail();
     }
 
-    fn outline_rows(&self) -> Vec<OutlineRow> {
-        build_outline_rows(&self.tickets, &self.visible, &self.outline_collapsed)
-    }
-
-    fn selected_outline_row(&self) -> Option<OutlineRow> {
-        self.outline_state
-            .selected()
-            .and_then(|selected| self.outline_rows().get(selected).copied())
-    }
-
-    fn next_outline_ticket(&mut self) {
-        let rows = self.outline_rows();
-        if rows.is_empty() {
-            self.outline_state.select(None);
-            return;
-        }
-        let selected = self.outline_state.selected().unwrap_or(0);
-        self.outline_state.select(Some((selected + 1) % rows.len()));
-        self.sync_outline_to_list_selection();
-        self.sync_open_detail();
-    }
-
-    fn previous_outline_ticket(&mut self) {
-        let rows = self.outline_rows();
-        if rows.is_empty() {
-            self.outline_state.select(None);
-            return;
-        }
-        let selected = self.outline_state.selected().unwrap_or(0);
-        let previous = selected
-            .checked_sub(1)
-            .unwrap_or_else(|| rows.len().saturating_sub(1));
-        self.outline_state.select(Some(previous));
-        self.sync_outline_to_list_selection();
-        self.sync_open_detail();
-    }
-
-    fn toggle_selected_outline_node(&mut self) {
-        let Some(row) = self.selected_outline_row() else {
-            return;
-        };
-        if !row.has_children {
-            return;
-        }
-        let id = self.tickets[row.ticket_idx].id;
-        if !self.outline_collapsed.remove(&id) {
-            self.outline_collapsed.insert(id);
-        }
-        self.sync_outline_selection();
-    }
-
-    fn expand_selected_outline_node(&mut self) {
-        let Some(row) = self.selected_outline_row() else {
-            return;
-        };
-        if row.has_children {
-            let id = self.tickets[row.ticket_idx].id;
-            self.outline_collapsed.remove(&id);
-            self.sync_outline_selection();
-        }
-    }
-
-    fn collapse_selected_outline_node(&mut self) {
-        let Some(row) = self.selected_outline_row() else {
-            return;
-        };
-        if row.has_children {
-            let id = self.tickets[row.ticket_idx].id;
-            self.outline_collapsed.insert(id);
-            self.sync_outline_selection();
-            return;
-        }
-
-        if row.depth == 0 {
-            return;
-        }
-        let Some(parent) = self.tickets[row.ticket_idx].parent else {
-            return;
-        };
-        if let Some(parent_row) = self
-            .outline_rows()
-            .iter()
-            .position(|candidate| self.tickets[candidate.ticket_idx].id == parent)
-        {
-            self.outline_state.select(Some(parent_row));
-            self.sync_outline_to_list_selection();
-            self.sync_open_detail();
-        }
-    }
-
     fn resize_detail(&mut self, delta: i16) {
         if self.detail.is_none() && self.writeup_detail.is_none() {
             self.status = Some("Open details first.".to_string());
@@ -5171,15 +4905,10 @@ impl App {
         let selected_id = self.selected_ticket().map(|ticket| ticket.id);
         let selected_writeup_id = self.selected_writeup().map(|writeup| writeup.id);
         let was_board = self.view == ViewMode::Board && self.detail.is_none();
-        let was_outline = self.view == ViewMode::Outline;
         self.reload_all(selected_id, selected_writeup_id)?;
         if was_board {
             if let Some(id) = selected_id {
                 self.select_board_ticket_by_id(id);
-            }
-        } else if was_outline {
-            if let Some(id) = selected_id {
-                self.select_outline_ticket_by_id(id);
             }
         }
         self.status = Some("Refreshed.".to_string());
@@ -5193,21 +4922,9 @@ impl App {
                 self.view = ViewMode::List;
                 TuiTab::Writeups
             }
-            TuiTab::Writeups => TuiTab::Dashboard,
+            TuiTab::Writeups => TuiTab::Issues,
             TuiTab::Dashboard => TuiTab::Issues,
         };
-    }
-
-    fn select_outline_ticket_by_id(&mut self, id: uuid::Uuid) {
-        let Some(row) = self
-            .outline_rows()
-            .iter()
-            .position(|row| self.tickets[row.ticket_idx].id == id)
-        else {
-            return;
-        };
-        self.outline_state.select(Some(row));
-        self.sync_outline_to_list_selection();
     }
 
     fn select_board_ticket_by_id(&mut self, id: uuid::Uuid) {
@@ -5240,26 +4957,6 @@ impl App {
             if let Some(id) = selected_id {
                 self.select_board_ticket_by_id(id);
             }
-        }
-        Ok(())
-    }
-
-    fn handle_outline_key(&mut self) -> Result<()> {
-        let selected_id = self.selected_ticket().map(|ticket| ticket.id);
-        if self.view == ViewMode::Outline && self.detail.is_none() {
-            self.view = ViewMode::List;
-            self.sync_outline_to_list_selection();
-            return Ok(());
-        }
-        if self.hide_subissues {
-            self.hide_subissues = false;
-            self.reload(selected_id)?;
-        }
-        self.view = ViewMode::Outline;
-        self.detail = None;
-        self.comments_mode = false;
-        if let Some(id) = selected_id {
-            self.select_outline_ticket_by_id(id);
         }
         Ok(())
     }
@@ -5325,9 +5022,6 @@ impl App {
         if let Some(idx) = self.selected_ticket_index() {
             self.detail = Some(idx);
             self.select_list_ticket_by_index(idx);
-            if self.view == ViewMode::Outline {
-                self.select_outline_ticket_by_id(self.tickets[idx].id);
-            }
             self.comments_mode = false;
             self.sync_comment_selection();
         }
@@ -5355,9 +5049,6 @@ impl App {
             self.list_state.select(Some(list_pos));
             self.detail = list_indices.get(list_pos).copied();
             self.comments_mode = false;
-            if self.view == ViewMode::Outline {
-                self.select_outline_ticket_by_id(id);
-            }
             self.sync_comment_selection();
         }
     }
@@ -5429,26 +5120,6 @@ impl App {
     fn sync_board_to_list_selection(&mut self) {
         if let Some(idx) = self.selected_ticket_index() {
             self.select_list_ticket_by_index(idx);
-        }
-    }
-
-    fn sync_outline_selection(&mut self) {
-        let rows = self.outline_rows();
-        if rows.is_empty() {
-            self.outline_state.select(None);
-            return;
-        }
-        let selected = self
-            .outline_state
-            .selected()
-            .unwrap_or(0)
-            .min(rows.len() - 1);
-        self.outline_state.select(Some(selected));
-    }
-
-    fn sync_outline_to_list_selection(&mut self) {
-        if let Some(row) = self.selected_outline_row() {
-            self.select_list_ticket_by_index(row.ticket_idx);
         }
     }
 
@@ -5556,9 +5227,6 @@ impl App {
             return tickets
                 .get(self.board_rows[self.board_column])
                 .map(|idx| **idx);
-        }
-        if self.view == ViewMode::Outline {
-            return self.selected_outline_row().map(|row| row.ticket_idx);
         }
         self.list_state
             .selected()
@@ -5848,12 +5516,7 @@ fn tabs_title(active: TuiTab, title: &str) -> String {
     } else {
         " writeups "
     };
-    let dashboard = if active == TuiTab::Dashboard {
-        "[dashboard]"
-    } else {
-        " dashboard "
-    };
-    format!("{issues} {writeups} {dashboard}  {title}")
+    format!("{issues} {writeups}  {title}")
 }
 
 fn ticket_list_line(
@@ -5891,38 +5554,20 @@ fn ticket_list_line(
     )
 }
 
-fn outline_ticket_line(
+fn issue_title_prefix(
     ticket: &Ticket,
-    depth: usize,
-    has_children: bool,
-    collapsed: bool,
-    width: usize,
-    current_user: &str,
-    has_writeups: bool,
-) -> Line<'static> {
-    let indent_width = depth.saturating_mul(2).min(width);
-    let marker = match (has_children, collapsed) {
-        (true, true) => "+",
-        (true, false) => "-",
-        (false, _) => " ",
+    ticket_by_id: &HashMap<uuid::Uuid, &Ticket>,
+    show_subissue_graph: bool,
+) -> String {
+    let mut prefix = if show_subissue_graph {
+        subissue_graph_prefix(ticket, ticket_by_id)
+    } else {
+        String::new()
     };
-    let marker_width = UnicodeWidthStr::width(marker);
-    let gap_width = usize::from(width > indent_width + marker_width);
-    let prefix_width = indent_width + marker_width + gap_width;
-    let mut spans = vec![
-        Span::raw(" ".repeat(indent_width)),
-        Span::styled(marker.to_string(), Style::default().fg(Color::Yellow)),
-        Span::raw(" ".repeat(gap_width)),
-    ];
-    let content = ticket_list_line(
-        ticket,
-        width.saturating_sub(prefix_width),
-        true,
-        current_user,
-        has_writeups,
-    );
-    spans.extend(content.spans);
-    Line::from(spans)
+    if !ticket.children.is_empty() {
+        prefix.push_str("[+] ");
+    }
+    prefix
 }
 
 fn subissue_graph_prefix(ticket: &Ticket, ticket_by_id: &HashMap<uuid::Uuid, &Ticket>) -> String {
@@ -5931,7 +5576,7 @@ fn subissue_graph_prefix(ticket: &Ticket, ticket_by_id: &HashMap<uuid::Uuid, &Ti
         return String::new();
     }
 
-    format!("{}╰┄ ", "┊".repeat(depth))
+    format!("{}╰┄ ", " ".repeat(depth))
 }
 
 fn subissue_depth(ticket: &Ticket, ticket_by_id: &HashMap<uuid::Uuid, &Ticket>) -> usize {
@@ -7937,8 +7582,29 @@ mod tests {
             .collect::<HashMap<_, _>>();
 
         assert_eq!(subissue_graph_prefix(&tickets[0], &ticket_by_id), "");
-        assert_eq!(subissue_graph_prefix(&tickets[1], &ticket_by_id), "┊╰┄ ");
-        assert_eq!(subissue_graph_prefix(&tickets[2], &ticket_by_id), "┊┊╰┄ ");
+        assert_eq!(subissue_graph_prefix(&tickets[1], &ticket_by_id), " ╰┄ ");
+        assert_eq!(subissue_graph_prefix(&tickets[2], &ticket_by_id), "  ╰┄ ");
+    }
+
+    #[test]
+    fn issue_title_prefix_marks_parents_even_when_graph_is_hidden() {
+        let root = uuid::Uuid::from_u128(1);
+        let child = uuid::Uuid::from_u128(2);
+        let tickets = vec![
+            test_ticket(root, None, &[child]),
+            test_ticket(child, Some(root), &[]),
+        ];
+        let ticket_by_id = tickets
+            .iter()
+            .map(|ticket| (ticket.id, ticket))
+            .collect::<HashMap<_, _>>();
+
+        assert_eq!(
+            issue_title_prefix(&tickets[0], &ticket_by_id, false),
+            "[+] "
+        );
+        assert_eq!(issue_title_prefix(&tickets[1], &ticket_by_id, false), "");
+        assert_eq!(issue_title_prefix(&tickets[1], &ticket_by_id, true), " ╰┄ ");
     }
 
     #[test]

--- a/crates/ticgit/src/commands/tui.rs
+++ b/crates/ticgit/src/commands/tui.rs
@@ -5931,12 +5931,7 @@ fn subissue_graph_prefix(ticket: &Ticket, ticket_by_id: &HashMap<uuid::Uuid, &Ti
         return String::new();
     }
 
-    let marker = if ticket.children.is_empty() {
-        "├╮ "
-    } else {
-        "╰┄ "
-    };
-    format!("{}{}", "┊".repeat(depth), marker)
+    format!("{}╰┄ ", "┊".repeat(depth))
 }
 
 fn subissue_depth(ticket: &Ticket, ticket_by_id: &HashMap<uuid::Uuid, &Ticket>) -> usize {
@@ -7943,7 +7938,7 @@ mod tests {
 
         assert_eq!(subissue_graph_prefix(&tickets[0], &ticket_by_id), "");
         assert_eq!(subissue_graph_prefix(&tickets[1], &ticket_by_id), "┊╰┄ ");
-        assert_eq!(subissue_graph_prefix(&tickets[2], &ticket_by_id), "┊┊├╮ ");
+        assert_eq!(subissue_graph_prefix(&tickets[2], &ticket_by_id), "┊┊╰┄ ");
     }
 
     #[test]

--- a/crates/ticgit/src/session_state.rs
+++ b/crates/ticgit/src/session_state.rs
@@ -36,6 +36,8 @@ pub struct State {
 pub struct ProjectSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detail_width_percent: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub show_subissues: Option<bool>,
 }
 
 /// A saved set of list filter parameters.


### PR DESCRIPTION
- hide subissues by default while preserving a U toggle
- mark parent issues with [+] in list rows
- keep dashboard on the d hotkey without listing it as a tab